### PR TITLE
gpm submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "third_party/inih"]
 	path = third_party/inih
 	url = https://github.com/benhoyt/inih.git
+[submodule "third_party/gpm"]
+	path = third_party/gpm
+	url = https://github.com/GP-Engine-team/gpm.git


### PR DESCRIPTION
I have added our homemade math library with the other submodules in `third_party/`.

Although our homemade math library is not a third party library, it is independent from the GP engine.
If you think the math library doesn't belong in`third_party/` , we can rename the `third_party/` folder to `dependencies/` or `externals/` or anything else that sound fitting to you.
We can also move the math library submodule to another folder, if that sounds better to you.