### PR TITLE
GPM submodule and Visual Studio configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "engine/third_party/gpm"]
 	path = engine/third_party/gpm
-	url = git@github.com:GP-Engine-team/gpm.git
+	url = https://github.com/GP-Engine-team/gpm.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "engine/third_party/gpm"]
 	path = engine/third_party/gpm
 	url = git@github.com:GP-Engine-team/gpm.git
+[submodule "gpm"]
+	url = https://github.com/GP-Engine-team/gpm.git
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "engine/third_party/gpm"]
+	path = engine/third_party/gpm
+	url = git@github.com:GP-Engine-team/gpm.git

--- a/editor/GPEditor.vcxproj
+++ b/editor/GPEditor.vcxproj
@@ -138,7 +138,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../editor/include;$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include/</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../editor/include;$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include/;$(SolutionDir)/../../engine/third_party/gpm/include;$(SolutionDir)/../engine/third_party/gpm/include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,7 +156,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../editor/include;$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include/</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../editor/include;$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include/;$(SolutionDir)/../../engine/third_party/gpm/include;$(SolutionDir)/../engine/third_party/gpm/include;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/engine/GPEngine.vcxproj
+++ b/engine/GPEngine.vcxproj
@@ -128,7 +128,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../engine/src;$(SolutionDir)/../../engine/third_party/include;$(SolutionDir)/../../engine/include;$(SolutionDir)src;$(SolutionDir)include;$(SolutionDir)third_party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../engine/src;$(SolutionDir)/../../engine/third_party/include;$(SolutionDir)/../../engine/include;$(SolutionDir)src;$(SolutionDir)include;$(SolutionDir)third_party;%(AdditionalIncludeDirectories);$(SolutionDir)/third_party/gpm/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -144,7 +144,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../engine/src;$(SolutionDir)/../../engine/third_party/include;$(SolutionDir)/../../engine/include;$(SolutionDir)src;$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../editor/include;$(SolutionDir)/../../engine/include;$(SolutionDir)/third_party/gpm/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -155,25 +155,27 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Renderer\iRenderer.hpp" />
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Renderer\rendererSDLOpGl33.hpp" />
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Window\iWindow.hpp" />
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Window\windowSDL.hpp" />
-    <ClInclude Include="include\Engine\Core\Debug\Assert.hpp" />
-    <ClInclude Include="include\Engine\Core\Debug\Log.hpp" />
-    <ClInclude Include="include\Engine\Core\Game\AbstractGame.hpp" />
-    <ClInclude Include="include\Engine\Core\Game\ContextStartup.hpp" />
-    <ClInclude Include="include\Engine\Core\HotReload\ReloadableCpp.hpp" />
-    <ClInclude Include="include\Engine\Core\TimeSystem\TimeSystem.hpp" />
-    <ClInclude Include="include\Engine\Core\Tools\Format.hpp" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include=".clang-format" />
     <None Include="src\Format.inl" />
     <None Include="src\Log.inl" />
     <None Include="src\ResourcesManager.inl" />
     <None Include="src\TimeSystem.inl" />
     <None Include="src\WindowGLFW.inl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="include\Engine\Core\Debug\Assert.hpp" />
+    <ClInclude Include="include\Engine\Core\Debug\Log.hpp" />
+    <ClInclude Include="include\Engine\Core\Game\AbstractGame.hpp" />
+    <ClInclude Include="include\Engine\Core\Game\ContextStartup.hpp" />
+    <ClInclude Include="include\Engine\Core\HotReload\ReloadableCpp.hpp" />
+    <ClInclude Include="include\Engine\Core\Rendering\Renderer\RendererGLFW_GL46.hpp" />
+    <ClInclude Include="include\Engine\Core\Rendering\Window\WindowGLFW.hpp" />
+    <ClInclude Include="include\Engine\Core\TimeSystem\TimeSystem.hpp" />
+    <ClInclude Include="include\Engine\Core\Tools\ClassUtility.hpp" />
+    <ClInclude Include="include\Engine\Core\Tools\Format.hpp" />
+    <ClInclude Include="include\Engine\Resources\ResourcesManager.hpp" />
+    <ClInclude Include="include\Engine\Resources\Scene.hpp" />
+    <ClInclude Include="include\Engine\Resources\SceneManager.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Log.cpp" />

--- a/engine/GPEngine.vcxproj.filters
+++ b/engine/GPEngine.vcxproj.filters
@@ -15,59 +15,68 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <None Include=".clang-format" />
+    <None Include="src\WindowGLFW.inl">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="src\Format.inl">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="src\Log.inl">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="src\ResourcesManager.inl">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="src\TimeSystem.inl">
+      <Filter>Source Files</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <ClInclude Include="include\Engine\Core\Debug\Assert.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Engine\Core\Debug\Log.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\Engine\Core\Tools\Format.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Renderer\iRenderer.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Renderer\rendererSDLOpGl33.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Window\iWindow.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\env-master\env-master\cygwin64\home\utilisateur\Linux\GameEngine3\include2\GE\Core\Rendering\Window\windowSDL.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="include\Engine\Core\HotReload\ReloadableCpp.hpp">
+    <ClInclude Include="include\Engine\Core\Game\AbstractGame.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Engine\Core\Game\ContextStartup.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="include\Engine\Core\Game\AbstractGame.hpp">
+    <ClInclude Include="include\Engine\Core\HotReload\ReloadableCpp.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Core\Rendering\Renderer\RendererGLFW_GL46.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Core\Rendering\Window\WindowGLFW.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\Engine\Core\TimeSystem\TimeSystem.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\Engine\Core\Tools\ClassUtility.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Core\Tools\Format.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Resources\ResourcesManager.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Resources\Scene.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\Engine\Resources\SceneManager.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <None Include="src\Log.inl">
+    <ClCompile Include="src\WindowGLFW.cpp">
       <Filter>Source Files</Filter>
-    </None>
-    <None Include="src\Format.inl">
-      <Filter>Source Files</Filter>
-    </None>
-    <None Include=".clang-format" />
-    <None Include="src\TimeSystem.inl">
-      <Filter>Source Files</Filter>
-    </None>
-    <None Include="src\ResourcesManager.inl">
-      <Filter>Source Files</Filter>
-    </None>
-    <None Include="src\WindowGLFW.inl">
-      <Filter>Source Files</Filter>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
+    </ClCompile>
     <ClCompile Include="src\Log.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -78,9 +87,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\TimeSystem.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="src\WindowGLFW.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/launcher/GPLauncher.vcxproj
+++ b/launcher/GPLauncher.vcxproj
@@ -128,7 +128,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../../engine/include;$(SolutionDir)/../../engine/src;$(SolutionDir)/include;$(SolutionDir)/../../engine/third_party/gpm/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/projects/GPGame/GPGame.vcxproj
+++ b/projects/GPGame/GPGame.vcxproj
@@ -139,7 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions) LIVE_RELOADED_CODE_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)/include/;$(SolutionDir)../../engine/src/;$(SolutionDir)../../engine/include/</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)/include/;$(SolutionDir)../../engine/src/;$(SolutionDir)../../engine/include/;$(SolutionDir)/../../engine/third_party/gpm/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>


### PR DESCRIPTION
This brings the GPM submodule, which can be used anywhere through the engine, the launcher, the game or the editor.
For instance:
```C++
#include "GPM/Matrix4.hpp"
```

Try to clone this branch on your machine, in a new folder, with:
```
git clone https://github.com/GP-Engine-team/GP_Engine.git test --recurse-submodules --branch feature/gpm_submodule
```

and try to open any solution and to add a GPM header