### PR TITLE
Feature/gpm submodule fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,1 @@
-[submodule "engine/third_party/gpm"]
-	path = engine/third_party/gpm
-	url = https://github.com/GP-Engine-team/gpm.git
-	branch = main
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,1 +1,5 @@
 
+[submodule "gpm"]
+	path = engine/third_party/gpm
+	url = https://github.com/GP-Engine-team/gpm.git
+	branch = develop

--- a/editor/GPEditor.vcxproj
+++ b/editor/GPEditor.vcxproj
@@ -145,7 +145,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalIncludeDirectories>$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include;$(ProjectDir)/include;$(GPEngineDir)include;$(GPEngineDir)src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GPEngineDir)third_party\gpm\src;$(GPEngineDir)third_party\gpm\include;$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include;$(ProjectDir)/include;$(GPEngineDir)include;$(GPEngineDir)src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/engine/GPEngine.vcxproj
+++ b/engine/GPEngine.vcxproj
@@ -152,7 +152,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(GPEngineDir)/src;$(GPEngineDir)/third_party/include/Refureku;$(GPEngineDir)/third_party/include/;$(GPEngineDir)/include;$(GPGameDir)src;$(GPGameDir)include;$(SolutionDir)third_party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GPEngineDir)third_party\gpm\include;$(GPEngineDir)third_party\gpm\src;$(GPEngineDir)/src;$(GPEngineDir)/third_party/include/Refureku;$(GPEngineDir)/third_party/include/;$(GPEngineDir)/include;$(GPGameDir)src;$(GPGameDir)include;$(SolutionDir)third_party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/launcher/GPLauncher.vcxproj
+++ b/launcher/GPLauncher.vcxproj
@@ -154,7 +154,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(GPEngineDir)/include;$(GPEngineDir)/src;$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GPEngineDir)third_party\gpm\include;$(GPEngineDir)third_party\gpm\src;$(GPEngineDir)/include;$(GPEngineDir)/src;$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/launcher/GPLauncher.vcxproj.filters
+++ b/launcher/GPLauncher.vcxproj.filters
@@ -27,7 +27,4 @@
       <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="GPLauncher.props" />
-  </ItemGroup>
 </Project>

--- a/projects/GPGame/GPGame.vcxproj
+++ b/projects/GPGame/GPGame.vcxproj
@@ -160,7 +160,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions) LIVE_RELOADED_CODE_EXPORTS;GAME_EXPORTS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include/;$(GPEngineDir)/src/;$(GPEngineDir)/include/</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(GPEngineDir)third_party\gpm\src;$(GPEngineDir)third_party\gpm\include;$(GPEngineDir)/third_party/include/Refureku;$(GPGameDir)/include/;$(GPEngineDir)/src/;$(GPEngineDir)/include/</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/projects/GPGame/src/game.cpp
+++ b/projects/GPGame/src/game.cpp
@@ -2,6 +2,8 @@
 
 #include "Engine/Core/Debug/Assert.hpp"
 
+using namespace GPE;
+
 extern "C" AbstractGame* createGameInstance()
 {
 	return new Game();


### PR DESCRIPTION
This pull request brings a fix to the gpm submodule:
- The full submodule name is now `gpm` instead of `engine/third_party/gpm`
- The branch of the submodule is now set to `develop`
- A `path` property was linked to the submodule, leading to `engine/third_party/gpm`

Pulling the submodule should never be a problem again.

It also contains a minor fix for an unresolved external identifier in `GPGame/src/game.cpp`