### PR TITLE
Level editor and scene view

### DIFF
--- a/editor/include/Editor/Editor.hpp
+++ b/editor/include/Editor/Editor.hpp
@@ -18,14 +18,18 @@ struct GLFWwindow;
 
 namespace GPE
 {
-class Scene;
+class AbstractGame;
 class IInspectable;
 class GameObject;
 class ReloadableCpp;
+class Scene;
 } // namespace GPE
+
 
 namespace Editor
 {
+
+class EditorStartup;
 
 class Editor
 {
@@ -45,19 +49,17 @@ public:
     GPE::ReloadableCpp* m_reloadableCpp = nullptr;
 
 private:
-    GPE::Scene& loadDefaultScene() const;
+    void setupDearImGui      ();
 
-    void setupDearImGui();
-
-    void renderLog();
-    void renderStyleEditor();
-    void renderMenuBar();
-    void renderGameControlBar();
-    void renderLevelEditor();
-    void renderGameView(GPE::AbstractGame* game);
-    void renderInspector();
-    void renderSceneGraph();
-    void renderExplorer();
+    void renderLog           ();
+    void renderStyleEditor   ();
+    void renderMenuBar       ();
+    void renderGameControlBar(EditorStartup& startup);
+    void renderLevelEditor   ();
+    void renderGameView      (EditorStartup& startup);
+    void renderInspector     ();
+    void renderSceneGraph    ();
+    void renderExplorer      ();
 
     /**
      * @brief Function that crate scene graph recursively for each node in imGui window.
@@ -71,8 +73,8 @@ public:
     Editor(GLFWwindow* window, GPE::Scene& editedScene);
 
     void setSceneInEdition(GPE::Scene& scene);
-    void update(GPE::AbstractGame* game);
-    void render(GPE::AbstractGame* game);
+    void update(EditorStartup& startup);
+    void render(EditorStartup& startup);
     bool isRunning();
 };
 

--- a/editor/include/Editor/EditorStartup.hpp
+++ b/editor/include/Editor/EditorStartup.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "Editor/Editor.hpp"
 #include "Engine/Core/Game/ContextStartup.hpp"
 #include "Engine/Core/HotReload/ReloadableCpp.hpp"
 #include "Editor.hpp"
@@ -20,9 +19,9 @@ namespace Editor
 class EditorStartup final : public ContextStartup
 {
 private:
-	const std::function<void(double, double)> m_fixedUpdate;
-	const std::function<void(double, double)> m_update;
-	const std::function<void()>               m_render;
+	std::function<void(double, double)> m_fixedUpdate;
+	std::function<void(double, double)> m_update;
+	const std::function<void()>			m_render;
 
 #ifdef NDEBUG
 	const char* gameDllPath = "./bin/Release/GPGame.dll";
@@ -42,8 +41,15 @@ public:
 	EditorStartup();
 	virtual ~EditorStartup() final;
 
-	void startGame();
+	void openGame ();
 	void closeGame();
+
+	void playGame ();
+	void pauseGame();
+	void stopGame ();
+
+	void renderGame();
+
 	virtual void update() override final;
 };
 

--- a/editor/include/Editor/GameControlBar.hpp
+++ b/editor/include/Editor/GameControlBar.hpp
@@ -11,6 +11,7 @@
 namespace Editor
 {
 
+class EditorStartup;
 class Editor;
 
 class GameControlBar
@@ -37,7 +38,7 @@ public:
     GameControlBar();
 
     // Methods
-    void render(class Editor& editor);
+    void render(EditorStartup& startup);
 };
 
 } // End of namespace Editor

--- a/editor/include/Editor/GameViewer.hpp
+++ b/editor/include/Editor/GameViewer.hpp
@@ -8,6 +8,8 @@
 
 #include "WindowFramebuffer.hpp"
 
+struct GLFWwindow;
+
 namespace Editor
 {
 
@@ -16,15 +18,20 @@ class EditorStartup;
 class GameViewer
 {
 public:
-    WindowFBO framebuffer;
+    WindowFBO            framebuffer;
+    GLFWwindow*          window;
 
 private:
-    bool      m_captureInputs;
+    bool                 m_captureInputs;
 
 public:
     GameViewer(int width = 1, int height = 1);
 
     void render(EditorStartup& startup);
+
+    void captureInputs();
+
+    void releaseInputs();
 };
 
 }

--- a/editor/include/Editor/GameViewer.hpp
+++ b/editor/include/Editor/GameViewer.hpp
@@ -8,13 +8,10 @@
 
 #include "WindowFramebuffer.hpp"
 
-namespace GPE
-{
-class AbstractGame;
-}
-
 namespace Editor
 {
+
+class EditorStartup;
 
 class GameViewer
 {
@@ -27,7 +24,7 @@ private:
 public:
     GameViewer(int width = 1, int height = 1);
 
-    void render(GPE::AbstractGame* game);
+    void render(EditorStartup& startup);
 };
 
 }

--- a/editor/include/Editor/SceneEditor.hpp
+++ b/editor/include/Editor/SceneEditor.hpp
@@ -17,12 +17,13 @@ public:
 	GPE::SceneViewer view;
 
 private:
-	void checkCursor(GPE::IInspectable*& inspectedObject);
+	void captureInputs(bool toggle);
+	void checkCursor  (GPE::IInspectable*& inspectedObject);
 
 public:
-	SceneEditor		(GPE::Scene& scene);
+	SceneEditor		  (GPE::Scene& scene);
 
-	void render		(GPE::IInspectable*& inspectedObject);
+	void render		  (GPE::IInspectable*& inspectedObject);
 };
 
 }

--- a/editor/src/Editor.cpp
+++ b/editor/src/Editor.cpp
@@ -1,25 +1,25 @@
-﻿#include "Editor/Editor.hpp"
+﻿#include <Editor/EditorStartup.hpp>
 
 // Engine
-#include "Engine/Core/Game/AbstractGame.hpp"
-#include "Engine/Core/HotReload/ReloadableCpp.hpp"
-#include "Engine/ECS/Component/Camera.hpp"
-#include "Engine/Engine.hpp"
-#include "Engine/Intermediate/GameObject.hpp"
-#include "Engine/Resources/Scene.hpp"
-#include "Engine/Resources/SceneManager.hpp"
-#include "Engine/Serialization/DataInspector.hpp"
-#include "Engine/Serialization/IInspectable.hpp"
-#include "Engine/Serialization/InspectContext.hpp"
+#include <Engine/Core/Game/AbstractGame.hpp>
+#include <Engine/Core/HotReload/ReloadableCpp.hpp>
+#include <Engine/ECS/Component/Camera.hpp>
+#include <Engine/Engine.hpp>
+#include <Engine/Intermediate/GameObject.hpp>
+#include <Engine/Resources/Scene.hpp>
+#include <Engine/Resources/SceneManager.hpp>
+#include <Engine/Serialization/DataInspector.hpp>
+#include <Engine/Serialization/IInspectable.hpp>
+#include <Engine/Serialization/InspectContext.hpp>
 
 // Editor
-#include "Editor/ExternalDeclarations.hpp"
+#include <Editor/ExternalDeclarations.hpp>
 
 // Third-party
-#include "GLFW/glfw3.h"
-#include "glad/glad.h"
-#include "imgui/backends/imgui_impl_glfw.h"
-#include "imgui/backends/imgui_impl_opengl3.h"
+#include <GLFW/glfw3.h>
+#include <glad/glad.h>
+#include <imgui/backends/imgui_impl_glfw.h>
+#include <imgui/backends/imgui_impl_opengl3.h>
 #include <imgui/imgui.h>
 
 // Hint to use GPU if available
@@ -35,11 +35,6 @@ namespace Editor
 using namespace GPE;
 
 /* ========================== Private methods ========================== */
-GPE::Scene& Editor::loadDefaultScene() const
-{
-    return GPE::Engine::getInstance()->sceneManager.loadScene("Empty scene");
-}
-
 void Editor::setupDearImGui()
 {
     ImGuiIO& io = ImGui::GetIO();
@@ -121,9 +116,9 @@ void Editor::renderMenuBar()
     }
 }
 
-void Editor::renderGameControlBar()
+void Editor::renderGameControlBar(EditorStartup& startup)
 {
-    m_gameControlBar.render(*this);
+    m_gameControlBar.render(startup);
 }
 
 void Editor::renderLevelEditor()
@@ -131,10 +126,9 @@ void Editor::renderLevelEditor()
     m_sceneEditor.render(m_inspectedObject);
 }
 
-
-void Editor::renderGameView(GPE::AbstractGame* game)
+void Editor::renderGameView(EditorStartup& startup)
 {
-    m_gameViewer.render(game);
+    m_gameViewer.render(startup);
 }
 
 void Editor::renderInspector()
@@ -256,7 +250,7 @@ void Editor::setSceneInEdition(GPE::Scene& scene)
     m_sceneEditor.view.bindScene(scene);
 }
 
-void Editor::update(GPE::AbstractGame* game)
+void Editor::update(EditorStartup& startup)
 {
     // Initialize a new frame
     ImGui_ImplOpenGL3_NewFrame();
@@ -273,9 +267,9 @@ void Editor::update(GPE::AbstractGame* game)
 
     ImGui::DockSpaceOverViewport(ImGui::GetWindowViewport());
 
-    renderGameControlBar();
+    renderGameControlBar(startup);
     renderLevelEditor();
-    renderGameView(game);
+    renderGameView(startup);
     renderSceneGraph();
     renderExplorer();
     renderInspector();
@@ -284,9 +278,9 @@ void Editor::update(GPE::AbstractGame* game)
         ImGui::ShowDemoWindow(&m_showImGuiDemoWindows);
 }
 
-void Editor::render(GPE::AbstractGame* game)
+void Editor::render(EditorStartup& startup)
 {
-    update(game);
+    update(startup);
 
     ImGui::Render();
 
@@ -297,6 +291,7 @@ void Editor::render(GPE::AbstractGame* game)
 
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
+
 
 bool Editor::isRunning()
 {

--- a/editor/src/Editor.cpp
+++ b/editor/src/Editor.cpp
@@ -249,20 +249,12 @@ Editor::Editor(GLFWwindow* window, GPE::Scene& editedScene)
 {
     glfwMaximizeWindow(window);
     setupDearImGui();
-
-    Log::getInstance()->logCallBack = [&](const char* msg) {
-        // Log in console
-        std::cout << msg;
-
-        // Log in log inspector
-        if (ImGui::GetCurrentContext() != nullptr)
-            m_logInspector.addLog(msg);
-    };
 }
 
 void Editor::setSceneInEdition(GPE::Scene& scene)
 {
     m_sceneEditor.view.bindScene(scene);
+    GPE::Engine::getInstance()->inputManager.setInputMode("Editor");
 }
 
 void Editor::update(EditorStartup& startup)

--- a/editor/src/GameControlBar.cpp
+++ b/editor/src/GameControlBar.cpp
@@ -1,13 +1,13 @@
 #include "Editor/GameControlBar.hpp"
-#include "Editor/Editor.hpp"
+#include "Editor/EditorStartup.hpp"
 
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
 
-using namespace GPE;
-
 namespace Editor
 {
+
+using namespace GPE;
 
 GameControlBar::GameControlBar()
     : playButtonTex{{"..\\..\\editor\\resources\\play.png", Texture::ETextureMinFilter::LINEAR,
@@ -19,30 +19,32 @@ GameControlBar::GameControlBar()
       stopButtonTex{{"..\\..\\editor\\resources\\stop.png", Texture::ETextureMinFilter::LINEAR,
                      Texture::ETextureMagFilter::LINEAR, Texture::ETextureWrapS::CLAMP_TO_EDGE,
                      Texture::ETextureWrapT::CLAMP_TO_EDGE, false, false}},
-      buttonColors{IM_COL32(66u, 150u, 255u, 102u), IM_COL32(50u, 50u, 50u, 255u)}, buttonMask{EButton::STOP}
+      buttonColors{IM_COL32(66u, 150u, 255u, 102u), IM_COL32(50u, 50u, 50u, 255u)},
+      buttonMask{STOP}
 {
 }
 
 // TODO: decide what to do with "editor" when clicking play/pause/stop
-void GameControlBar::render(Editor& editor)
+void GameControlBar::render(EditorStartup& startup)
 {
-    // Remove the docking tab bar
-    ImGuiWindowClass window_class;
-    window_class.DockNodeFlagsOverrideSet = ImGuiDockNodeFlags_NoTabBar;
-    ImGui::SetNextWindowClass(&window_class);
+    { // Remove the docking tab bar
+        ImGuiWindowClass window_class;
+        window_class.DockNodeFlagsOverrideSet = ImGuiDockNodeFlags_NoTabBar;
+        ImGui::SetNextWindowClass(&window_class);
+    }
 
     // Make an undecorated window for the control buttons
-    ImGui::Begin("Game controls", nullptr, ImGuiWindowFlags_NoDecoration);
+    if (ImGui::Begin("Game controls", nullptr, ImGuiWindowFlags_NoDecoration))
     {
         ImVec2 buttonSize, cursorPos;
 
         { // Compute the size and position of the buttons
-            const ImVec2 winSize{ImGui::GetContentRegionAvail()};
+            const ImVec2 winSize  {ImGui::GetContentRegionAvail()};
             const float  extraSide{ImGui::GetCurrentWindow()->WindowPadding.y * .5f};
-            const float  side{winSize.y + extraSide};
+            const float  side     {winSize.y + extraSide};
 
             buttonSize.x = buttonSize.y = side;
-            cursorPos                   = {winSize.x * .5f - side * 1.5f, extraSide};
+            cursorPos    = {winSize.x * .5f - side * 1.5f, extraSide};
         }
 
         // Render the "Play" button
@@ -55,12 +57,12 @@ void GameControlBar::render(Editor& editor)
             if (buttonMask & PLAY)
             {
                 buttonMask = STOP;
-                // TODO: "Play" is on. Tell the editor the game should be playing
+                startup.stopGame();
             }
             else
             {
                 buttonMask = PLAY;
-                // TODO: "Play" is off. Tell the editor the game should be stopped
+                startup.playGame();
             }
         }
 
@@ -76,12 +78,12 @@ void GameControlBar::render(Editor& editor)
             if (buttonMask & PAUSE)
             {
                 buttonMask = PLAY;
-                // TODO: "Pause" is on. Tell the editor the game should be launch then immediatly paused
+                startup.playGame();
             }
             else
             {
                 buttonMask = PAUSE;
-                // TODO: "Pause" is off. Tell the editor the game should keep on playing
+                startup.pauseGame();
             }
         }
 
@@ -94,7 +96,7 @@ void GameControlBar::render(Editor& editor)
         if (ImGui::IsItemClicked())
         {
             buttonMask = STOP;
-            // TODO: "Stop" was pressed. Tell the editor the game should be stopped
+            startup.stopGame();
         }
     }
     ImGui::End();

--- a/editor/src/GameViewer.cpp
+++ b/editor/src/GameViewer.cpp
@@ -1,9 +1,9 @@
 #include "Editor/GameViewer.hpp"
 
 #include "Engine/Core/Debug/Assert.hpp"
-#include "Engine/Core/Game/AbstractGame.hpp"
-#include "glad/glad.h"
+#include "Editor/EditorStartup.hpp"
 
+#include "glad/glad.h"
 #include "imgui/imgui.h"
 
 namespace Editor
@@ -13,19 +13,19 @@ GameViewer::GameViewer(int width, int height)
     : framebuffer{width, height}, m_captureInputs{false}
 {}
 
-void GameViewer::render(GPE::AbstractGame* game)
+void GameViewer::render(EditorStartup& startup)
 {
     // Use the whole window content
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {.0f, .0f});
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, .0f);
 
-    ImGui::Begin("Game view");
+    if (ImGui::Begin("Game view"))
     {
         const ImVec2 size{ImGui::GetContentRegionAvail()};
 
         framebuffer.resize(static_cast<int>(size.x), static_cast<int>(size.y));
         framebuffer.bind();
-        game->render();
+        startup.renderGame();
 
         ImGui::Image((void*)(intptr_t)framebuffer.textureID(), size, {.0f, 1.f}, {1.f, .0f});
     }

--- a/editor/src/GameViewer.cpp
+++ b/editor/src/GameViewer.cpp
@@ -3,16 +3,46 @@
 #include <Editor/EditorStartup.hpp>
 
 #include <Engine/Core/Game/AbstractGame.hpp>
+#include <Engine/ECS/Component/Camera.hpp>
+#include <Engine/Engine.hpp>
 
-#include <glad/glad.h>
+#include <GLFW/glfw3.h>
 #include <imgui/imgui.h>
+#include <imgui/backends/imgui_impl_glfw.h>
 #include <imgui/imgui_internal.h>
 
 namespace Editor
 {
 
+using namespace GPE;
+
+void GameViewer::releaseInputs()
+{
+    InputManager& io = Engine::getInstance()->inputManager;
+    io.setCursorLockState(false);
+    io.setCursorTrackingState(false);
+    io.restorePreviousInputMode();
+
+    m_captureInputs = false;
+}
+
+
+void GameViewer::captureInputs()
+{
+    Log::getInstance()->log("GameViewer::captureInputs()");
+    InputManager& io = Engine::getInstance()->inputManager;
+    io.setCursorLockState(true);
+    io.setCursorTrackingState(true);
+    io.setInputMode("Game");
+
+    m_captureInputs = true;
+}
+
+
 GameViewer::GameViewer(int width, int height)
-    : framebuffer{width, height}, m_captureInputs{false}
+    : framebuffer{width, height},
+      window{GPE::Engine::getInstance()->window.getGLFWWindow()},
+      m_captureInputs{false}
 {}
 
 
@@ -24,15 +54,38 @@ void GameViewer::render(EditorStartup& startup)
 
     if (ImGui::Begin("Game view"))
     {
+        // Decide what to do with inputs
+        if (startup.game().state == EGameState::PLAYING   &&
+            !m_captureInputs                              &&
+            ImGui::IsWindowHovered()                      &&
+            ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+        {
+            captureInputs();
+        }
+
+        // The input manager is not used here because this class and its methods cannot be serialized
+        else if (m_captureInputs && glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+        {
+            releaseInputs();
+        }
+
         const ImVec2 size{ImGui::GetContentRegionAvail()};
+
+        // Set main camera
+        Camera& cam = Engine::getInstance()->sceneManager.getCurrentScene()->sceneRenderer.setMainCamera(0);
+
+        // Update game viewport
         startup.game().setViewport(ImGui::GetWindowPos().x + ImGui::GetCurrentWindow()->Viewport->CurrWorkOffsetMin.x,
                                    ImGui::GetWindowPos().y + ImGui::GetCurrentWindow()->Viewport->CurrWorkOffsetMin.y,
                                    size.x, size.y);
-
-        framebuffer.resize(static_cast<int>(size.x), static_cast<int>(size.y));
+        
+        // Update camera's aspect and resizing FBO
+        cam.setAspect(size.x / size.y);
+        framebuffer.resize(int(size.x), int(size.y));
         framebuffer.bind();
-        startup.game().render();
 
+        // Render
+        startup.game().render();
         ImGui::Image((void*)(intptr_t)framebuffer.textureID(), size, {.0f, 1.f}, {1.f, .0f});
     }
     ImGui::End();

--- a/editor/src/LogInspector.cpp
+++ b/editor/src/LogInspector.cpp
@@ -1,127 +1,137 @@
-#include "Editor/LogInspector.hpp"
-#include "Engine/Core//Debug/Log.hpp"
+#include <Editor/LogInspector.hpp>
+#include <Engine/Core/Debug/Log.hpp>
 #include <iostream>
 
 namespace Editor
 {
 
-	LogInspector::LogInspector()
+LogInspector::LogInspector()
+{
+	GPE::Log::getInstance()->logCallBack = [&](const char* msg)
 	{
-		m_autoScroll = true;
+		// Log in console
+		std::cerr << msg;
+
+		// Log in log inspector
+		if (ImGui::GetCurrentContext() != nullptr)
+			addLog(msg);
+	};
+
+	m_autoScroll = true;
+	clear();
+
+	for (auto&& str : GPE::Log::getInstance()->getLogs())
+	{
+		std::cerr << str;
+		addLog(str.c_str());
+	}
+}
+
+LogInspector::~LogInspector()
+{
+	clear();
+}
+
+void LogInspector::clear()
+{
+	m_buf.clear();
+	m_lineOffsets.clear();
+	m_lineOffsets.push_back(0);
+}
+
+void LogInspector::addLog(const char* fmt, ...) IM_FMTARGS(2)
+{
+	int     old_size = m_buf.size();
+	va_list args;
+	va_start(args, fmt);
+	m_buf.appendfv(fmt, args);
+	va_end(args);
+	for (int new_size = m_buf.size(); old_size < new_size; old_size++)
+		if (m_buf[old_size] == '\n')
+			m_lineOffsets.push_back(old_size + 1);
+}
+
+void LogInspector::draw(const char* title, bool* p_open)
+{
+	// Options menu
+	if (ImGui::BeginPopup("Options"))
+	{
+		ImGui::Checkbox("Auto-scroll", &m_autoScroll);
+		ImGui::EndPopup();
+	}
+
+	// Main window
+	if (ImGui::Button("Options"))
+		ImGui::OpenPopup("Options");
+	ImGui::SameLine();
+	bool isClear = ImGui::Button("Clear");
+	ImGui::SameLine();
+	bool isCopy = ImGui::Button("Copy");
+	ImGui::SameLine();
+	m_filter.Draw("Filter", -100.0f);
+
+	ImGui::Separator();
+	ImGui::BeginChild("scrolling", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+
+	if (isClear)
 		clear();
 
-		for (auto&& str : GPE::Log::getInstance()->getLogs())
+	if (isCopy)
+		ImGui::LogToClipboard();
+
+	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
+	const char* buf = m_buf.begin();
+	const char* buf_end = m_buf.end();
+	if (m_filter.IsActive())
+	{
+		// In this example we don't use the clipper when m_filter is enabled.
+		// This is because we don't have a random access on the result on our filter.
+		// A real application processing logs with ten of thousands of entries may want to store the result of
+		// search/filter.. especially if the filtering function is not trivial (e.g. reg-exp).
+		for (int line_no = 0; line_no < m_lineOffsets.Size; line_no++)
 		{
-			std::cout << str;
-			addLog(str.c_str());
+			const char* line_start = buf + m_lineOffsets[line_no];
+			const char* line_end =
+				(line_no + 1 < m_lineOffsets.Size) ? (buf + m_lineOffsets[line_no + 1] - 1) : buf_end;
+			if (m_filter.PassFilter(line_start, line_end))
+				ImGui::TextUnformatted(line_start, line_end);
 		}
 	}
-
-	LogInspector::~LogInspector()
+	else
 	{
-		clear();
-	}
-
-	void LogInspector::clear()
-	{
-		m_buf.clear();
-		m_lineOffsets.clear();
-		m_lineOffsets.push_back(0);
-	}
-
-	void LogInspector::addLog(const char* fmt, ...) IM_FMTARGS(2)
-	{
-		int     old_size = m_buf.size();
-		va_list args;
-		va_start(args, fmt);
-		m_buf.appendfv(fmt, args);
-		va_end(args);
-		for (int new_size = m_buf.size(); old_size < new_size; old_size++)
-			if (m_buf[old_size] == '\n')
-				m_lineOffsets.push_back(old_size + 1);
-	}
-
-	void LogInspector::draw(const char* title, bool* p_open)
-	{
-		// Options menu
-		if (ImGui::BeginPopup("Options"))
+		// The simplest and easy way to display the entire buffer:
+		//   ImGui::TextUnformatted(buf_begin, buf_end);
+		// And it'll just work. TextUnformatted() has specialization for large blob of text and will fast-forward
+		// to skip non-visible lines. Here we instead demonstrate using the clipper to only process lines that are
+		// within the visible area.
+		// If you have tens of thousands of items and their processing cost is non-negligible, coarse clipping them
+		// on your side is recommended. Using ImGuiListClipper requires
+		// - A) random access into your data
+		// - B) items all being the  same height,
+		// both of which we can handle since we an array pointing to the beginning of each line of text.
+		// When using the filter (in the block of code above) we don't have random access into the data to display
+		// anymore, which is why we don't use the clipper. Storing or skimming through the search result would make
+		// it possible (and would be recommended if you want to search through tens of thousands of entries).
+		ImGuiListClipper clipper;
+		clipper.Begin(m_lineOffsets.Size);
+		while (clipper.Step())
 		{
-			ImGui::Checkbox("Auto-scroll", &m_autoScroll);
-			ImGui::EndPopup();
-		}
-
-		// Main window
-		if (ImGui::Button("Options"))
-			ImGui::OpenPopup("Options");
-		ImGui::SameLine();
-		bool isClear = ImGui::Button("Clear");
-		ImGui::SameLine();
-		bool isCopy = ImGui::Button("Copy");
-		ImGui::SameLine();
-		m_filter.Draw("Filter", -100.0f);
-
-		ImGui::Separator();
-		ImGui::BeginChild("scrolling", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
-
-		if (isClear)
-			clear();
-
-		if (isCopy)
-			ImGui::LogToClipboard();
-
-		ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-		const char* buf = m_buf.begin();
-		const char* buf_end = m_buf.end();
-		if (m_filter.IsActive())
-		{
-			// In this example we don't use the clipper when m_filter is enabled.
-			// This is because we don't have a random access on the result on our filter.
-			// A real application processing logs with ten of thousands of entries may want to store the result of
-			// search/filter.. especially if the filtering function is not trivial (e.g. reg-exp).
-			for (int line_no = 0; line_no < m_lineOffsets.Size; line_no++)
+			for (int line_no = clipper.DisplayStart; line_no < clipper.DisplayEnd; line_no++)
 			{
 				const char* line_start = buf + m_lineOffsets[line_no];
 				const char* line_end =
 					(line_no + 1 < m_lineOffsets.Size) ? (buf + m_lineOffsets[line_no + 1] - 1) : buf_end;
-				if (m_filter.PassFilter(line_start, line_end))
-					ImGui::TextUnformatted(line_start, line_end);
+				ImGui::TextUnformatted(line_start, line_end);
 			}
 		}
-		else
-		{
-			// The simplest and easy way to display the entire buffer:
-			//   ImGui::TextUnformatted(buf_begin, buf_end);
-			// And it'll just work. TextUnformatted() has specialization for large blob of text and will fast-forward
-			// to skip non-visible lines. Here we instead demonstrate using the clipper to only process lines that are
-			// within the visible area.
-			// If you have tens of thousands of items and their processing cost is non-negligible, coarse clipping them
-			// on your side is recommended. Using ImGuiListClipper requires
-			// - A) random access into your data
-			// - B) items all being the  same height,
-			// both of which we can handle since we an array pointing to the beginning of each line of text.
-			// When using the filter (in the block of code above) we don't have random access into the data to display
-			// anymore, which is why we don't use the clipper. Storing or skimming through the search result would make
-			// it possible (and would be recommended if you want to search through tens of thousands of entries).
-			ImGuiListClipper clipper;
-			clipper.Begin(m_lineOffsets.Size);
-			while (clipper.Step())
-			{
-				for (int line_no = clipper.DisplayStart; line_no < clipper.DisplayEnd; line_no++)
-				{
-					const char* line_start = buf + m_lineOffsets[line_no];
-					const char* line_end =
-						(line_no + 1 < m_lineOffsets.Size) ? (buf + m_lineOffsets[line_no + 1] - 1) : buf_end;
-					ImGui::TextUnformatted(line_start, line_end);
-				}
-			}
-			clipper.End();
-		}
-		ImGui::PopStyleVar();
-
-		if (m_autoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
-			ImGui::SetScrollHereY(1.0f);
-
-		ImGui::EndChild();
+		clipper.End();
 	}
+	ImGui::PopStyleVar();
 
+	if (m_autoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY())
+		ImGui::SetScrollHereY(1.0f);
+
+	ImGui::EndChild();
 }
+
+} // End of namespace Editor

--- a/editor/src/SceneEditor.cpp
+++ b/editor/src/SceneEditor.cpp
@@ -23,7 +23,6 @@ void SceneEditor::checkCursor(GPE::IInspectable*& inspectedObject)
         {
             if (GameObject* const selectionGameObject = view.pScene->getWorld()
                                                         .getGameObjectCorrespondingToID(idSelectedGameObject))
-
             {
                 inspectedObject = selectionGameObject;
             }
@@ -61,7 +60,7 @@ void SceneEditor::render(GPE::IInspectable*& inspectedObject)
         view.resize(static_cast<int>(size.x), static_cast<int>(size.y));
         view.render();
 
-        ImGui::Image((void*)(intptr_t)view.textureID, size, {0.f, 1.f}, {1.f, 0.f});
+        ImGui::Image((void*)(intptr_t)view.textureID, size, {.0f, 1.f}, {1.f, .0f});
     }
 
     ImGui::End();

--- a/editor/src/SceneEditor.cpp
+++ b/editor/src/SceneEditor.cpp
@@ -37,9 +37,10 @@ void SceneEditor::checkCursor(GPE::IInspectable*& inspectedObject)
 }
 
 // ========================== Public methods ==========================
-SceneEditor::SceneEditor(GPE::Scene& scene) : view{scene}
-{
-}
+SceneEditor::SceneEditor(GPE::Scene& scene)
+    : view{scene}
+{}
+
 
 void SceneEditor::render(GPE::IInspectable*& inspectedObject)
 {

--- a/editor/src/SceneEditor.cpp
+++ b/editor/src/SceneEditor.cpp
@@ -1,8 +1,7 @@
-﻿#include "Editor/SceneEditor.hpp"
+﻿#include <Editor/SceneEditor.hpp>
 
-#include "Engine/Intermediate/GameObject.hpp"
-#include "Engine/Resources/Scene.hpp"
-#include "imgui/imgui.h"
+#include <Engine/Engine.hpp>
+#include <imgui/imgui.h>
 
 namespace Editor
 {
@@ -10,31 +9,61 @@ namespace Editor
 using namespace GPE;
 
 // ========================== Private methods ==========================
+void SceneEditor::captureInputs(bool toggle)
+{
+    InputManager& io = Engine::getInstance()->inputManager;
+    io.setCursorLockState(toggle);
+    io.setCursorTrackingState(toggle);
+    view.captureInputs(toggle);
+
+    if (toggle)
+    {
+        io.setInputMode("Level editor");
+    }
+    else
+    {
+        io.restorePreviousInputMode();
+    }
+}
+
+
 void SceneEditor::checkCursor(GPE::IInspectable*& inspectedObject)
 {
-    if (ImGui::IsMouseClicked(0))
+    const bool hovered = ImGui::IsWindowHovered();
+
+    if (hovered)
     {
-        const bool hovered = ImGui::IsWindowHovered();
-        view.captureInputs(hovered);
-
-        const unsigned int idSelectedGameObject = view.getHoveredGameObjectID();
-
-        if (idSelectedGameObject && hovered)
+        if (ImGui::IsMouseClicked(ImGuiMouseButton_Right))
         {
-            if (GameObject* const selectionGameObject = view.pScene->getWorld()
-                                                        .getGameObjectCorrespondingToID(idSelectedGameObject))
-            {
-                inspectedObject = selectionGameObject;
-            }
+            captureInputs(true);
+        }
 
-            else
+        else if (ImGui::IsMouseReleased(ImGuiMouseButton_Right))
+        {
+            captureInputs(false);
+        }
+
+        else if (ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+        {
+            const unsigned int idSelectedGameObject = view.getHoveredGameObjectID();
+            if (idSelectedGameObject)
             {
-                GPE::Log::getInstance()->logError(
-                    stringFormat("No gameObject corresponding to the id %i", idSelectedGameObject));
+                if (GameObject* const selectionGameObject = view.pScene->getWorld()
+                                                            .getGameObjectCorrespondingToID(idSelectedGameObject))
+                {
+                    inspectedObject = selectionGameObject;
+                }
+
+                else
+                {
+                    GPE::Log::getInstance()->logError(
+                        stringFormat("No gameObject corresponding to the id %i", idSelectedGameObject));
+                }
             }
         }
     }
 }
+
 
 // ========================== Public methods ==========================
 SceneEditor::SceneEditor(GPE::Scene& scene)
@@ -48,13 +77,14 @@ void SceneEditor::render(GPE::IInspectable*& inspectedObject)
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {.0f, .0f});
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, .0f);
 
-    if (ImGui::Begin(view.pScene->getWorld().getName().c_str(), nullptr, ImGuiWindowFlags_NoBackground))
+    const std::string windowName = "Scene editor (" + view.pScene->getWorld().getName() + ')';
+    if (ImGui::Begin(windowName.c_str()))
     {
-        checkCursor(inspectedObject);
-
         const ImVec2 size{ImGui::GetContentRegionAvail()};
 
-        view.resize(static_cast<int>(size.x), static_cast<int>(size.y));
+        checkCursor(inspectedObject);
+
+        view.resize(int(size.x), int(size.y));
         view.render();
 
         ImGui::Image((void*)(intptr_t)view.textureID, size, {.0f, 1.f}, {1.f, .0f});

--- a/engine/include/Engine/Core/Game/AbstractGame.hpp
+++ b/engine/include/Engine/Core/Game/AbstractGame.hpp
@@ -9,8 +9,18 @@
 namespace GPE
 {
 
+enum class EGameState : unsigned char
+{
+    STOPPED = 0u,
+    PLAYING = (1u << 0),
+    PAUSED  = (1u << 1)
+};
+
 class AbstractGame
 {
+public:
+    EGameState state = EGameState::STOPPED;
+
 public:
     virtual ~AbstractGame() = default;
 

--- a/engine/include/Engine/ECS/Component/BehaviourComponent.hpp
+++ b/engine/include/Engine/ECS/Component/BehaviourComponent.hpp
@@ -39,11 +39,11 @@ namespace GPE RFKNamespace()
         {
         }
 
-        virtual void fixedUpdate(float deltaTime)
+        virtual void fixedUpdate(double deltaTime)
         {
         }
 
-        virtual void update(float deltaTime)
+        virtual void update(double deltaTime)
         {
         }
 

--- a/engine/include/Engine/ECS/Component/Camera.hpp
+++ b/engine/include/Engine/ECS/Component/Camera.hpp
@@ -65,20 +65,20 @@ namespace GPE RFKNamespace()
 
         struct PerspectiveCreateArg
         {
+            const char* name    = "Camera";
             float       aspect  = 16.f / 9.f;
             float       nearVal = 0.001f;
-            float       farVal  = 10.f;
+            float       farVal  = 1000.f;
             float       fovY    = 70.f;
-            const char* name    = "Camera";
         };
 
         struct OrthographicCreateArg
         {
+            const char* name    = "Camera";
             float       hSide   = 1.f;
             float       vSide   = 1.f;
             float       nearVal = 0.001f;
-            float       farVal  = 10.f;
-            const char* name    = "Camera";
+            float       farVal  = 1000.f;
         };
 
     protected:

--- a/engine/include/Engine/ECS/Component/InputComponent.hpp
+++ b/engine/include/Engine/ECS/Component/InputComponent.hpp
@@ -10,12 +10,12 @@
 #include <string>
 #include <unordered_map>
 
-#include "Engine/Core/Tools/FunctionPtr.hpp"
-#include "Engine/ECS/Component/Component.hpp"
-#include "Engine/Serialization/ComponentGen.h"
+#include <Engine/Core/Tools/FunctionPtr.hpp>
+#include <Engine/ECS/Component/Component.hpp>
+#include <Engine/Serialization/ComponentGen.h>
 
 // Generated
-#include "Generated/InputComponent.rfk.h"
+#include <Generated/InputComponent.rfk.h>
 
 enum class EKeyMode
 {

--- a/engine/include/Engine/ECS/Component/Model.hpp
+++ b/engine/include/Engine/ECS/Component/Model.hpp
@@ -34,7 +34,7 @@ namespace GPE RFKNamespace()
         bool enableBackFaceCulling = true;
     };
 
-    template <>
+    template<>
     void DataInspector::inspect(GPE::InspectContext & context, SubModel & inspected);
 
     bool isSubModelHasPriorityOverAnother(const SubModel* lhs, const SubModel* rhs) noexcept;
@@ -51,9 +51,9 @@ namespace GPE RFKNamespace()
         RFKField(Inspect()) std::list<SubModel> m_subModels;
 
     public:
-        Model(GameObject & owner);
+        Model(GameObject& owner);
 
-        Model(GameObject & owner, const CreateArg& arg);
+        Model(GameObject& owner, const CreateArg& arg);
 
         Model(const Model& other) noexcept = delete;
         Model(Model && other) noexcept;

--- a/engine/include/Engine/ECS/Component/Physics/CharacterController/CharacterController.hpp
+++ b/engine/include/Engine/ECS/Component/Physics/CharacterController/CharacterController.hpp
@@ -30,7 +30,7 @@ namespace GPE RFKNamespace()
         CharacterController& operator=(CharacterController const& other) noexcept = delete;
         CharacterController& operator=(CharacterController&& other) noexcept = delete;
 
-        void update(float deltaTime) noexcept;
+        void update(double deltaTime) noexcept;
 
         virtual ~CharacterController() noexcept;
 

--- a/engine/include/Engine/ECS/System/BehaviourSystem.hpp
+++ b/engine/include/Engine/ECS/System/BehaviourSystem.hpp
@@ -42,9 +42,9 @@ public:
     void start() const noexcept;
     void onGUI() const noexcept;
 
-    void fixedUpdate(float deltaTime) noexcept;
+    void fixedUpdate(double deltaTime) noexcept;
 
-    void update(float deltaTime) const noexcept;
+    void update(double deltaTime) const noexcept;
 };
 
 } /*namespace GPE*/

--- a/engine/include/Engine/ECS/System/InputManagerGLFW.hpp
+++ b/engine/include/Engine/ECS/System/InputManagerGLFW.hpp
@@ -5,7 +5,7 @@
  */
 
 #pragma once
-#include <Engine/Core/Tools/ClassUtility.hpp>
+
 #include <Engine/ECS/Component/InputComponent.hpp>
 #include <Engine/Resources/Cursor.hpp>
 #include <string>
@@ -23,7 +23,8 @@ private:
     std::unordered_map<int, bool>             m_stateMap;
     std::unordered_map<int, bool>             m_lastStateMap;
     std::unordered_map<int, InputComponent*>  m_inputComponents;
-    std::string                               m_currentInputMode = "none";
+    std::string                               m_currentInputMode  = "";
+    std::string                               m_previousInputMode = "";
     Cursor                                    m_cursor;
 
 public:
@@ -66,7 +67,7 @@ public:
     /**
      * @brief Set cursor mode using GLFW Enum
      */
-    void setCursorMode(GLFWwindow* window, int mode) noexcept;
+    void setCursorMode(int mode) noexcept;
 
     /**
      * @brief Set the current input mode
@@ -74,6 +75,13 @@ public:
      * @return
      */
     inline void setInputMode(const std::string& inputMode) noexcept;
+
+     /**
+     * @brief Restore the input mode previously set before the one currently active
+     * 
+     * Internally, swaps m_previousInputMode and m_currentInputMode
+     */
+    inline void restorePreviousInputMode() noexcept;
 
     /**
      * @brief Set the current input mode

--- a/engine/include/Engine/ECS/System/InputManagerGLFW.inl
+++ b/engine/include/Engine/ECS/System/InputManagerGLFW.inl
@@ -2,6 +2,12 @@
 {
 void InputManager::bindInput(int key, const std::string& action) noexcept
 {
+    using const_iterator = std::unordered_multimap<int, std::string>::const_iterator;
+    const const_iterator it = m_actionMap.find(key);
+
+    if (it != m_actionMap.end() && it->second == action)
+        return;
+
     m_actionMap.emplace(key, action);
 }
 
@@ -30,8 +36,15 @@ inline const Cursor& InputManager::getCursor() const noexcept
 
 void InputManager::setInputMode(const std::string& inputMode) noexcept
 {
-    m_currentInputMode = inputMode;
+    m_previousInputMode = std::move(m_currentInputMode);
+    m_currentInputMode  = inputMode;
 }
+
+void InputManager::restorePreviousInputMode() noexcept
+{
+    std::swap(m_previousInputMode, m_currentInputMode);
+}
+
 
 void InputManager::setCursorTrackingState(bool trackState) noexcept
 {

--- a/engine/include/Engine/ECS/System/PhysXSystem.hpp
+++ b/engine/include/Engine/ECS/System/PhysXSystem.hpp
@@ -1,7 +1,7 @@
 ﻿/*
  * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
  * This file is subject to the LGNU license terms in the LICENSE file
- *	found in the top-level directory of this distribution.
+ * found in the top-level directory of this distribution.
  */
 
 #pragma once
@@ -36,6 +36,18 @@ public:
 
 class PhysXSystem
 {
+public:
+    physx::PxFoundation*              foundation;
+    physx::PxPvd*                     pvd;
+    physx::PxPhysics*                 physics;
+    physx::PxCooking*                 cooking;
+    physx::PxScene*                   scene;
+    physx::PxControllerManager*       manager;
+    std::vector<RigidbodyStatic*>     rigidbodyStatics;
+    std::vector<RigidbodyDynamic*>    rigidbodyDynamics;
+    std::vector<CharacterController*> characterControllers;
+    bool                              drawDebugShapes{false};
+
 public:
     PhysXSystem();
     ~PhysXSystem();
@@ -92,17 +104,6 @@ public:
     static inline physx::PxExtendedVec3 GPMVec3ToPxExtendedVec3(const GPM::Vec3& vector) noexcept;
     static inline GPM::Quat             PxQuatToGPMQuat(const physx::PxQuat& quaternion) noexcept;
     static inline physx::PxQuat         GPMQuatToPxQuat(const GPM::Quat& quaternion) noexcept;
-
-public:
-    physx::PxFoundation*              foundation;
-    physx::PxPvd*                     pvd;
-    physx::PxPhysics*                 physics;
-    physx::PxCooking*                 cooking;
-    physx::PxScene*                   scene;
-    physx::PxControllerManager*       manager;
-    std::vector<RigidbodyStatic*>     rigidbodyStatics;
-    std::vector<RigidbodyDynamic*>    rigidbodyDynamics;
-    std::vector<CharacterController*> characterControllers;
 };
 
 #include <Engine/ECS/System/PhysXSystem.inl>

--- a/engine/include/Engine/ECS/System/RenderSystem.hpp
+++ b/engine/include/Engine/ECS/System/RenderSystem.hpp
@@ -88,20 +88,21 @@ public:
     RenderSystem() noexcept;
     ~RenderSystem() noexcept;
 
-    void tryToBindShader(Shader& shader);
-    void tryToBindMaterial(Shader& shader, Material& material);
-    void tryToBindTexture(unsigned int textureID);
-    void tryToBindMesh(unsigned int meshID);
+    void tryToBindShader        (Shader& shader);
+    void tryToBindMaterial      (Shader& shader, Material& material);
+    void tryToBindTexture       (unsigned int textureID);
+    void tryToBindMesh          (unsigned int meshID);
     void tryToSetBackFaceCulling(bool useBackFaceCulling);
 
-    void setMainCamera(Camera& newMainCamera) noexcept;
+    void setMainCamera          (Camera& newMainCamera) noexcept;
+    Camera& setMainCamera       (int index) noexcept;
 
     void resetCurrentRenderPassKey();
 
-    bool isOnFrustum(const Frustum& camFrustum, const SubModel* pSubModel) const noexcept;
-    void drawModelPart(const SubModel& subModel);
-    void sendModelDataToShader(Camera& camToUse, Shader& shader, SubModel& subModel);
-    void sendDataToInitShader(Camera& camToUse, Shader* pCurrentShaderUse);
+    bool isOnFrustum            (const Frustum& camFrustum, const SubModel* pSubModel) const noexcept;
+    void drawModelPart          (const SubModel& subModel);
+    void sendModelDataToShader  (Camera& camToUse, Shader& shader, SubModel& subModel);
+    void sendDataToInitShader   (Camera& camToUse, Shader* pCurrentShaderUse);
 
     RenderPipeline defaultRenderPipeline() const noexcept;
     RenderPipeline gameObjectIdentifierPipeline() const noexcept;
@@ -110,15 +111,15 @@ public:
     void drawDebugSphere(const GPM::Vec3& position, float radius,
                          const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f},
                          EDebugShapeMode mode = EDebugShapeMode::FILL, bool enableBackFaceCullling = true) noexcept;
-    void drawDebugCube(const GPM::Vec3& position, const GPM::Quat& rotation, const GPM::Vec3& scale,
-                       const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f},
-                       EDebugShapeMode mode = EDebugShapeMode::FILL, bool enableBackFaceCullling = true) noexcept;
-    void drawDebugQuad(const GPM::Vec3& position, const GPM::Vec3& dir, const GPM::Vec3& scale,
-                       const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f},
-                       EDebugShapeMode mode = EDebugShapeMode::FILL, bool enableBackFaceCullling = true) noexcept;
+    void drawDebugCube  (const GPM::Vec3& position, const GPM::Quat& rotation, const GPM::Vec3& scale,
+                         const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f},
+                         EDebugShapeMode mode = EDebugShapeMode::FILL, bool enableBackFaceCullling = true) noexcept;
+    void drawDebugQuad  (const GPM::Vec3& position, const GPM::Vec3& dir, const GPM::Vec3& scale,
+                         const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f},
+                         EDebugShapeMode mode = EDebugShapeMode::FILL, bool enableBackFaceCullling = true) noexcept;
 
-    void drawDebugLine(const GPM::Vec3& pt1, const GPM::Vec3& pt2, float width = 1.f,
-                       const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f}, bool smooth = true) noexcept;
+    void drawDebugLine  (const GPM::Vec3& pt1, const GPM::Vec3& pt2, float width = 1.f,
+                         const ColorRGBA& color = ColorRGBA{0.5f, 0.f, 0.f, 0.5f}, bool smooth = true) noexcept;
 
     void displayGameObjectRef(const GameObject& go, float dist = 100.f, float size = 10.f) noexcept;
 

--- a/engine/include/Engine/ECS/System/SoundSystem.hpp
+++ b/engine/include/Engine/ECS/System/SoundSystem.hpp
@@ -1,12 +1,13 @@
 ﻿/*
  * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
  * This file is subject to the LGNU license terms in the LICENSE file
- *	found in the top-level directory of this distribution.
+ * found in the top-level directory of this distribution.
  */
 
 #pragma once
 #include "Engine/ECS/Component/AudioComponent.hpp"
 #include <unordered_map>
+
 namespace GPE
 {
 class SoundSystem

--- a/engine/include/Engine/ECS/System/SoundSystem.inl
+++ b/engine/include/Engine/ECS/System/SoundSystem.inl
@@ -1,6 +1,4 @@
-﻿#include "Engine/ECS/System/SoundSystem.hpp"
-
-int SoundSystem::addComponent(AudioComponent* input) noexcept
+﻿int SoundSystem::addComponent(AudioComponent* input) noexcept
 {
     int key = static_cast<int>(m_audioComponents.size());
     m_audioComponents.emplace(key, input);

--- a/engine/include/Engine/Engine.hpp
+++ b/engine/include/Engine/Engine.hpp
@@ -6,21 +6,21 @@
 
 #pragma once
 
-#include "Engine/Core/Rendering/Renderer/RendererGLFW_GL46.hpp"
-#include "Engine/Core/Rendering/Window/WindowGLFW.hpp"
-#include "Engine/ECS/System/BehaviourSystem.hpp"
-#include "Engine/ECS/System/InputManagerGLFW.hpp"
-#include "Engine/ECS/System/PhysXSystem.hpp"
-#include "Engine/ECS/System/TimeSystem.hpp"
-#include "Engine/Resources/ResourcesManagerType.hpp"
-#include "Engine/Resources/SceneManager.hpp"
-#include <Engine/ECS/System/SoundSystem.hpp>
+#include "Core/Rendering/Renderer/RendererGLFW_GL46.hpp"
+#include "Core/Rendering/Window/WindowGLFW.hpp"
+#include "ECS/System/BehaviourSystem.hpp"
+#include "ECS/System/InputManagerGLFW.hpp"
+#include "ECS/System/PhysXSystem.hpp"
+#include "ECS/System/SoundSystem.hpp"
+#include "ECS/System/TimeSystem.hpp"
+#include "Resources/ResourcesManagerType.hpp"
+#include "Resources/SceneManager.hpp"
 
 namespace GPE
 {
 
-/**
- * The Engine class defines the `GetInstance` method that serves as an
+/*
+ * The Engine class defines the `getInstance` method that serves as an
  * alternative to constructor and lets clients access the same instance of this
  * class over and over.
  */

--- a/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
+++ b/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
@@ -51,6 +51,7 @@ private:
 private:
     void initializeFramebuffer();
     void initializePickingFBO ();
+    void initializeInputs();
 
 public:
     SceneViewer(GPE::Scene& viewed, int width = 1, int height = 1);

--- a/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
+++ b/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
@@ -19,10 +19,10 @@ class SceneViewer
 {
 // ==== Data members ====
 public:
-    GameObject*    cameraOwner = nullptr;
-    FreeFly&      freeFly;
-    Camera&       camera;
-    Scene*        pScene;
+    GameObject* cameraOwner = nullptr;
+    FreeFly&    freeFly;
+    Camera&     camera;
+    Scene*      pScene;
 
     // Keep track of cameraOwner, from the perspective of
     // its parent's list of child

--- a/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
+++ b/engine/include/Engine/Intermediate/Viewers/SceneViewer.hpp
@@ -14,15 +14,17 @@ namespace GPE
 class FreeFly;
 class Scene;
 class Camera;
+class InputComponent;
 
 class SceneViewer
 {
 // ==== Data members ====
 public:
-    GameObject* cameraOwner = nullptr;
-    FreeFly&    freeFly;
-    Camera&     camera;
-    Scene*      pScene;
+    GameObject*     cameraOwner;
+    FreeFly&        freeFly;
+    Camera&         camera;
+    InputComponent& inputs;
+    Scene*          pScene;
 
     // Keep track of cameraOwner, from the perspective of
     // its parent's list of child
@@ -45,7 +47,7 @@ public:
     int           height;
 
 private:
-    bool          m_captureInputs;
+    bool          m_capturingInputs;
     
 // ==== Methods ====
 private:

--- a/engine/include/Engine/Resources/ResourcesManagerType.hpp
+++ b/engine/include/Engine/Resources/ResourcesManagerType.hpp
@@ -20,6 +20,7 @@
 
 namespace GPE
 {
+
 using ResourceManagerType = ResourcesManager<std::vector<Mesh>, Model::CreateArg, Mesh, Shader, Texture, RenderBuffer,
                                              RenderTexture, std::vector<Material>, Material, Sound::Buffer>;
 

--- a/engine/include/Engine/Resources/SceneManager.hpp
+++ b/engine/include/Engine/Resources/SceneManager.hpp
@@ -59,6 +59,7 @@ public:
                      EResourceManagement   resourcesloadType  = EResourceManagement::RECYCLING);
 
     void removeScene(const std::string& sceneName);
+    void removeScene(Scene& scene);
 };
 
 } /*namespace GPE*/

--- a/engine/include/Engine/Resources/Script/FreeFly.hpp
+++ b/engine/include/Engine/Resources/Script/FreeFly.hpp
@@ -38,13 +38,16 @@ public:
     inline void forward();
 
     RFKMethod()
-    inline void back();
+    inline void backward();
 
     RFKMethod()
     inline void left();
 
     RFKMethod()
     inline void right();
+
+    RFKMethod()
+    inline void walk();
 
     RFKMethod()
     inline void sprint();

--- a/engine/include/Engine/Resources/Script/FreeFly.hpp
+++ b/engine/include/Engine/Resources/Script/FreeFly.hpp
@@ -6,10 +6,10 @@
 
 #pragma once
 
-#include "Engine/ECS/Component/BehaviourComponent.hpp"
-#include "Engine/Intermediate/GameObject.hpp"
-#include "GPM/Vector3.hpp"
-#include "Generated/FreeFly.rfk.h"
+#include <Engine/ECS/Component/BehaviourComponent.hpp>
+#include <Engine/Intermediate/GameObject.hpp>
+#include <GPM/Vector3.hpp>
+#include <Generated/FreeFly.rfk.h>
 
 namespace GPE RFKNamespace()
 {
@@ -17,8 +17,11 @@ namespace GPE RFKNamespace()
 class RFKClass() FreeFly final : public BehaviourComponent
 {
 protected:
-    float m_speed         = 1.f;
-    float m_rotationSpeed = .001f;
+    TimeSystem& timeSys;
+    float       m_walkSpeed     = 15.f; // m/s
+    float       m_sprintSpeed   = 30.f;
+    float       m_speed         = m_walkSpeed;
+    float       m_rotationSpeed = .001f;
 
 public:
     FreeFly() noexcept = default;
@@ -53,7 +56,7 @@ public:
     RFKMethod()
     inline void sprint();
 
-    void update(float deltaTime) final;
+    void update(double deltaTime) final;
 
     FreeFly& operator=(FreeFly&& other) noexcept;
 

--- a/engine/include/Engine/Resources/Script/FreeFly.inl
+++ b/engine/include/Engine/Resources/Script/FreeFly.inl
@@ -1,45 +1,45 @@
 inline void FreeFly::up()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorUp() * m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorUp() * m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::down()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorUp() * -m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorUp() * -m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::forward()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorForward() * -m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorForward() * -m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::backward()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorForward() * m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorForward() * m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::left()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorRight() * -m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorRight() * -m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::right()
 {
-    getOwner().getTransform().translate(getOwner().getTransform().getVectorRight() * m_speed);
+    getOwner().getTransform().translate(getOwner().getTransform().getVectorRight() * m_speed * float(timeSys.getUnscaledDeltaTime()));
 }
 
 
 inline void FreeFly::walk()
 {
-    m_speed = 1.f;
+    m_speed = m_walkSpeed;
 }
 
 inline void FreeFly::sprint()
 {
-    m_speed = 3.f;
+    m_speed = m_sprintSpeed;
 }

--- a/engine/include/Engine/Resources/Script/FreeFly.inl
+++ b/engine/include/Engine/Resources/Script/FreeFly.inl
@@ -16,7 +16,7 @@ inline void FreeFly::forward()
 }
 
 
-inline void FreeFly::back()
+inline void FreeFly::backward()
 {
     getOwner().getTransform().translate(getOwner().getTransform().getVectorForward() * m_speed);
 }
@@ -34,7 +34,12 @@ inline void FreeFly::right()
 }
 
 
+inline void FreeFly::walk()
+{
+    m_speed = 1.f;
+}
+
 inline void FreeFly::sprint()
 {
-    m_speed = 2.f;
+    m_speed = 3.f;
 }

--- a/engine/src/BehaviourSystem.cpp
+++ b/engine/src/BehaviourSystem.cpp
@@ -135,7 +135,7 @@ void BehaviourSystem::onGUI() const noexcept
     }
 }
 
-void BehaviourSystem::fixedUpdate(float deltaTime) noexcept
+void BehaviourSystem::fixedUpdate(double deltaTime) noexcept
 {
     for (auto&& behaviour : m_fixedUpdateFunctions)
     {
@@ -143,7 +143,7 @@ void BehaviourSystem::fixedUpdate(float deltaTime) noexcept
     }
 }
 
-void BehaviourSystem::update(float deltaTime) const noexcept
+void BehaviourSystem::update(double deltaTime) const noexcept
 {
     for (auto&& behaviour : m_updateFunctions)
     {

--- a/engine/src/FreeFly.cpp
+++ b/engine/src/FreeFly.cpp
@@ -6,17 +6,18 @@
 
 #pragma once
 
-#include "Engine/Engine.hpp"
+#include <Engine/Engine.hpp>
 
-#include "Engine/Resources/Script/FreeFly.hpp"
-#include "Generated/FreeFly.rfk.h"
+#include <Engine/Resources/Script/FreeFly.hpp>
+#include <Generated/FreeFly.rfk.h>
 File_GENERATED
 
 namespace GPE
 {
 
 FreeFly::FreeFly(GameObject& owner) noexcept
-    : BehaviourComponent(owner)
+    : BehaviourComponent(owner),
+      timeSys{Engine::getInstance()->timeSystem}
 {
     enableUpdate(true);
 }
@@ -28,7 +29,7 @@ FreeFly::~FreeFly() noexcept
 }
 
 
-void FreeFly::update(float deltaTime)
+void FreeFly::update(double deltaTime)
 {
     const GPM::Vec2 deltaPos = Engine::getInstance()->inputManager.getCursor().deltaPos;
 
@@ -39,6 +40,7 @@ void FreeFly::update(float deltaTime)
 }
 
 
+// TODO: the rotation should depend on deltaTime
 void FreeFly::rotate(const GPM::Vector2& deltaDisplacement)
 {
     using namespace GPM;

--- a/engine/src/FreeFly.cpp
+++ b/engine/src/FreeFly.cpp
@@ -31,18 +31,26 @@ FreeFly::~FreeFly() noexcept
 
 void FreeFly::update(float deltaTime)
 {
-    rotate(Engine::getInstance()->inputManager.getCursor().deltaPos);
+    const GPM::Vec2 deltaPos = Engine::getInstance()->inputManager.getCursor().deltaPos;
+
+    if (deltaPos.x || deltaPos.y)
+    {
+        rotate(deltaPos);
+    }
 }
 
 
 void FreeFly::rotate(const GPM::Vector2& deltaDisplacement)
 {
-    const GPM::Quaternion newRot =
-        getOwner().getTransform().getSpacialAttribut().rotation *
-        GPM::Quaternion::angleAxis(deltaDisplacement.y * m_rotationSpeed, {1.f, .0f, .0f});
+    using namespace GPM;
 
-    getOwner().getTransform().setRotation(
-        GPM::Quaternion::angleAxis(deltaDisplacement.x * m_rotationSpeed, {.0f, 1.f, .0f}) * newRot);
+    const Quat& orientation{getOwner().getTransform().getSpacialAttribut().rotation};
+    const Vec2  axis       {deltaDisplacement.rotated90()};
+    const Quat  rotX       {Quat::angleAxis(axis.x * m_rotationSpeed, Vec3::right())};
+    const Quat  rotY       {Quat::angleAxis(axis.y * m_rotationSpeed, Vec3::up())};
+    const Quat  newRot     {rotY * orientation * rotX};
+
+    getOwner().getTransform().setRotation(newRot);
 }
 
 

--- a/engine/src/FreeFly.cpp
+++ b/engine/src/FreeFly.cpp
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include "Engine/ECS/Component/InputComponent.hpp"
-#include "Engine/ECS/System/InputManagerGLFW.hpp"
 #include "Engine/Engine.hpp"
 
 #include "Engine/Resources/Script/FreeFly.hpp"
@@ -20,31 +18,12 @@ namespace GPE
 FreeFly::FreeFly(GameObject& owner) noexcept
     : BehaviourComponent(owner)
 {
-        enableUpdate(true);
-        InputComponent& input = owner.addComponent<InputComponent>();
-
-        input.bindAction("up", EKeyMode::KEY_DOWN, this, "up");
-        input.bindAction("down", EKeyMode::KEY_DOWN, this, "down");
-        input.bindAction("right", EKeyMode::KEY_DOWN, this, "right");
-        input.bindAction("left", EKeyMode::KEY_DOWN, this, "left");
-        input.bindAction("forward", EKeyMode::KEY_DOWN, this, "forward");
-        input.bindAction("back", EKeyMode::KEY_DOWN, this, "back");
-        input.bindAction("sprint", EKeyMode::KEY_DOWN, this, "sprint");
+    enableUpdate(true);
 }
 
 
 FreeFly::~FreeFly() noexcept
 {
-    // TODO: unbind actions
-    // InputComponent& input = owner.addComponent<InputComponent>();
-    // input.unbindAction("up");
-    // input.unbindAction("down");
-    // input.unbindAction("right");
-    // input.unbindAction("left");
-    // input.unbindAction("forward");
-    // input.unbindAction("backward");
-    // input.unbindAction("sprint");
-
     DataChunk<FreeFly>::getInstance()->destroy(this);
 }
 
@@ -66,12 +45,7 @@ void FreeFly::rotate(const GPM::Vector2& deltaDisplacement)
 
 void FreeFly::update(float deltaTime)
 {
-    m_speed = 1.f;
-
-    if (Engine::getInstance()->inputManager.getCursor().deltaPos.sqrLength() > .1f)
-    {
-        rotate(Engine::getInstance()->inputManager.getCursor().deltaPos);
-    }
+    rotate(Engine::getInstance()->inputManager.getCursor().deltaPos);
 }
 
 

--- a/engine/src/InputComponent.cpp
+++ b/engine/src/InputComponent.cpp
@@ -4,7 +4,6 @@
 
 #include <functional>
 
-// Generated
 #include "Generated/InputComponent.rfk.h"
 File_GENERATED
 

--- a/engine/src/InputComponent.cpp
+++ b/engine/src/InputComponent.cpp
@@ -57,7 +57,7 @@ void InputComponent::setActive(bool newState) noexcept
 {
     m_isActivated = newState;
     if (m_isActivated)
-        Engine::getInstance()->inputManager.addComponent(*this);
+        m_key = Engine::getInstance()->inputManager.addComponent(*this);
     else
         Engine::getInstance()->inputManager.removeComponent(m_key);
 }

--- a/engine/src/InputManagerGLFW.cpp
+++ b/engine/src/InputManagerGLFW.cpp
@@ -1,11 +1,9 @@
-﻿#include "Engine/ECS/System/InputManagerGLFW.hpp"
-#include "Engine/Core/Rendering/Window/WindowGLFW.hpp"
-#include "GPM/DebugOutput.hpp"
-#include <Engine/Core/Debug/Log.hpp>
+﻿#include <Engine/ECS/System/InputManagerGLFW.hpp>
+
 #include <Engine/Engine.hpp>
 #include <GLFW/glfw3.h>
-#include <backends/imgui_impl_glfw.h>
-#include <imgui.h>
+#include <imgui/backends/imgui_impl_glfw.h>
+#include <imgui/imgui.h>
 
 using namespace std;
 using namespace GPE;
@@ -90,12 +88,14 @@ void InputManager::cursorPositionCallback(GLFWwindow* window, double xpos, doubl
 {
     if (m_cursor.tracked)
     {
-        m_cursor.deltaPos =
-            Vec2{static_cast<GPM::f32>(xpos) - m_cursor.position.x, static_cast<GPM::f32>(ypos) - m_cursor.position.y};
+        // GLFW cursor position is expressed relative to the top-left corner of the screen
+        // Internally, we represent deltaPos' y-axis going up, not down like GLFW
+        m_cursor.deltaPos.x = f32(xpos) - m_cursor.position.x;
+        m_cursor.deltaPos.y = m_cursor.position.y - f32(ypos);
     }
 
-    m_cursor.position.x = static_cast<GPM::f32>(xpos);
-    m_cursor.position.y = static_cast<GPM::f32>(ypos);
+    m_cursor.position.x = f32(xpos);
+    m_cursor.position.y = f32(ypos);
 }
 
 void setCursorCallback(GLFWwindow* window, double xpos, double ypos) noexcept

--- a/engine/src/MeshInspectorPanel.cpp
+++ b/engine/src/MeshInspectorPanel.cpp
@@ -1,12 +1,12 @@
-#include "Engine/Core/Tools/ImGuiTools.hpp"
 #include "Engine/Serialization/FileExplorer.hpp"
+#include "Engine/Core/Tools/ImGuiTools.hpp"
 #include "Engine/Serialization/GPMDataInspector.hpp"
 #include "Engine/Serialization/STDDataInspector.hpp"
 
 #include "Engine/Serialization/MeshInspectorPanel.hpp"
 File_GENERATED
 
-    namespace GPE
+namespace GPE
 {
 
     MeshInspectorPanel::MeshInspectorPanel(const std::string& inPath)

--- a/engine/src/Model.cpp
+++ b/engine/src/Model.cpp
@@ -33,7 +33,8 @@ bool GPE::isSubModelHasPriorityOverAnother(const SubModel* lhs, const SubModel* 
            (lhs->pMaterial->isOpaque() && !rhs->pMaterial->isOpaque());
 }
 
-Model::Model(Model&& other) noexcept : Component(other.getOwner()), m_subModels{other.m_subModels}
+Model::Model(Model&& other) noexcept
+    : Component(other.getOwner()), m_subModels{other.m_subModels}
 {
     auto&& itNew = m_subModels.begin();
     auto&& itOld = other.m_subModels.begin();
@@ -49,11 +50,13 @@ Model::~Model()
         getOwner().pOwnerScene->sceneRenderer.removeSubModel(subMesh);
 }
 
-Model::Model(GameObject& owner) : Model(owner, CreateArg{})
+Model::Model(GameObject& owner)
+    : Model(owner, CreateArg{})
 {
 }
 
-Model::Model(GameObject& owner, const CreateArg& arg) : Component{owner}, m_subModels{arg.subModels}
+Model::Model(GameObject& owner, const CreateArg& arg)
+    : Component{owner}, m_subModels{arg.subModels}
 {
     for (SubModel& subMesh : m_subModels)
     {

--- a/engine/src/Physics/CharacterController/CharacterController.cpp
+++ b/engine/src/Physics/CharacterController/CharacterController.cpp
@@ -9,7 +9,7 @@
 
 File_GENERATED
 
-    using namespace GPE;
+using namespace GPE;
 using namespace physx;
 
 CharacterController::CharacterController(GameObject& owner) noexcept : Component(owner)
@@ -38,7 +38,7 @@ CharacterController::CharacterController() noexcept
     //GPE::Engine::getInstance()->physXSystem.addComponent(this);
 }
 
-void CharacterController::update(float deltaTime) noexcept
+void CharacterController::update(double deltaTime) noexcept
 {
     physx::PxControllerFilters filters;
     updateForce();
@@ -55,7 +55,7 @@ void CharacterController::update(float deltaTime) noexcept
 
         if (m_hasGravity)
         {
-            addForce(GPM::Vec3{0, -1.f, 0} * m_gravity);
+            addForce({.0f, -m_gravity, .0f});
         }
     }
 

--- a/engine/src/Physics/PhysXSystem.cpp
+++ b/engine/src/Physics/PhysXSystem.cpp
@@ -105,7 +105,8 @@ void PhysXSystem::advance(double deltaTime) noexcept
         }
     }
 
-    drawDebugScene();
+    if (drawDebugShapes)
+        drawDebugScene();
 }
 
 void PhysXSystem::drawDebugScene()

--- a/engine/src/RenderSystem.cpp
+++ b/engine/src/RenderSystem.cpp
@@ -5,24 +5,24 @@
 #include <map> //std::map
 #include <memory>
 
-#include "Engine/Core/Rendering/Renderer/RendererGLFW_GL46.hpp"
-#include "Engine/Core/Rendering/Window/WindowGLFW.hpp"
-#include "Engine/Core/Tools/BranchPrediction.hpp"
-#include "Engine/ECS/Component/Camera.hpp"
-#include "Engine/ECS/Component/Light/Light.hpp"
-#include "Engine/ECS/Component/Model.hpp"
-#include "Engine/Engine.hpp"
-#include "Engine/Intermediate/GameObject.hpp"
-#include "Engine/Resources/Mesh.hpp"
-#include "Engine/Resources/RenderBuffer.hpp"
-#include "Engine/Resources/RenderTexture.hpp"
-#include "Engine/Resources/Shader.hpp"
-#include "GPM/Matrix4.hpp"
-#include "GPM/Shape3D/AABB.hpp"
-#include "GPM/Shape3D/Sphere.hpp"
-#include "GPM/Shape3D/Volume.hpp"
-#include "GPM/ShapeRelation/AABBPlane.hpp"
-#include "GPM/ShapeRelation/SpherePlane.hpp"
+#include <Engine/Core/Rendering/Renderer/RendererGLFW_GL46.hpp>
+#include <Engine/Core/Rendering/Window/WindowGLFW.hpp>
+#include <Engine/Core/Tools/BranchPrediction.hpp>
+#include <Engine/ECS/Component/Camera.hpp>
+#include <Engine/ECS/Component/Light/Light.hpp>
+#include <Engine/ECS/Component/Model.hpp>
+#include <Engine/Engine.hpp>
+#include <Engine/Intermediate/GameObject.hpp>
+#include <Engine/Resources/Mesh.hpp>
+#include <Engine/Resources/RenderBuffer.hpp>
+#include <Engine/Resources/RenderTexture.hpp>
+#include <Engine/Resources/Shader.hpp>
+#include <GPM/Matrix4.hpp>
+#include <GPM/Shape3D/AABB.hpp>
+#include <GPM/Shape3D/Sphere.hpp>
+#include <GPM/Shape3D/Volume.hpp>
+#include <GPM/ShapeRelation/AABBPlane.hpp>
+#include <GPM/ShapeRelation/SpherePlane.hpp>
 
 #include <imgui/backends/imgui_impl_opengl3.h>
 #include <imgui/imgui.h>
@@ -281,6 +281,14 @@ void RenderSystem::setMainCamera(Camera& newMainCamera) noexcept
 {
     m_mainCamera = &newMainCamera;
 }
+
+
+Camera& RenderSystem::setMainCamera(int index) noexcept
+{
+    m_mainCamera = m_pCameras[index % m_pCameras.size()];
+    return *m_mainCamera;
+}
+
 
 void RenderSystem::resetCurrentRenderPassKey()
 {

--- a/engine/src/SceneManager.cpp
+++ b/engine/src/SceneManager.cpp
@@ -80,3 +80,9 @@ void SceneManager::removeScene(const std::string& sceneName)
             m_pCurrentScene = &m_scenes.begin()->second;
     }
 }
+
+
+void SceneManager::removeScene(Scene& scene)
+{
+    removeScene(scene.m_name);
+}

--- a/engine/src/SceneViewer.cpp
+++ b/engine/src/SceneViewer.cpp
@@ -118,7 +118,7 @@ void SceneViewer::initializeInputs()
 SceneViewer::SceneViewer(GPE::Scene& viewed, int width_, int height_)
     : cameraOwner       {new GameObject(viewed, {"Editor camera", {}, &viewed.getWorld()})},
       freeFly           {cameraOwner->addComponent<FreeFly>()},
-      camera            {cameraOwner->addComponent<Camera>(Camera::PerspectiveCreateArg{width_ / (float)height_, .001f, 1000.f, 90.f})},
+      camera            {cameraOwner->addComponent<Camera>(Camera::PerspectiveCreateArg{"Editor camera", width_ / (float)height_, .001f, 1000.f, 90.f})},
       pScene            {&viewed},
       it                {viewed.getWorld().children.emplace(viewed.getWorld().children.end(), cameraOwner)},
       textureID         {0u},

--- a/engine/src/SceneViewer.cpp
+++ b/engine/src/SceneViewer.cpp
@@ -1,11 +1,15 @@
 ﻿#include "Engine/Intermediate/Viewers/SceneViewer.hpp"
 
-#include "Engine/ECS/Component/Camera.hpp"
-#include "Engine/Engine.hpp"
-#include "Engine/Resources/Scene.hpp"
-#include "Engine/Resources/Script/FreeFly.hpp"
+// Engine
+#include <Engine/ECS/Component/Camera.hpp>
+#include <Engine/ECS/Component/InputComponent.hpp>
+#include <Engine/ECS/System/InputManagerGLFW.hpp>
+#include <Engine/Engine.hpp>
+#include <Engine/Resources/Scene.hpp>
+#include <Engine/Resources/Script/FreeFly.hpp>
 
-#include "glad/glad.h"
+// Third-party
+#include <glad/glad.h>
 
 namespace GPE
 {
@@ -96,6 +100,19 @@ void SceneViewer::initializePickingFBO()
 }
 
 
+void SceneViewer::initializeInputs()
+{
+    GPE::InputComponent& input = cameraOwner.addComponent<GPE::InputComponent>();
+
+    input.bindAction("up",      EKeyMode::KEY_DOWN, &freeFly, "up");
+    input.bindAction("down",    EKeyMode::KEY_DOWN, &freeFly, "down");
+    input.bindAction("right",   EKeyMode::KEY_DOWN, &freeFly, "right");
+    input.bindAction("left",    EKeyMode::KEY_DOWN, &freeFly, "left");
+    input.bindAction("forward", EKeyMode::KEY_DOWN, &freeFly, "forward");
+    input.bindAction("back",    EKeyMode::KEY_DOWN, &freeFly, "backward");
+    input.bindAction("sprint",  EKeyMode::KEY_PRESSED, &freeFly, "sprint");
+    input.bindAction("sprint",  EKeyMode::KEY_RELEASED, &freeFly, "walk");
+}
 
 
 // ========================== Public methods ==========================
@@ -129,6 +146,16 @@ SceneViewer::SceneViewer(GPE::Scene& viewed, int width_, int height_)
 
 SceneViewer::~SceneViewer()
 {
+    // TODO: unbind actions
+    // InputComponent& input = owner.addComponent<InputComponent>();
+    // input.unbindAction("up");
+    // input.unbindAction("down");
+    // input.unbindAction("right");
+    // input.unbindAction("left");
+    // input.unbindAction("forward");
+    // input.unbindAction("backward");
+    // input.unbindAction("sprint");
+
     //cameraOwner.destroyUniqueComponentNow<Camera>();
     //cameraOwner.destroyUniqueComponentNow<FreeFly>();
     pScene->getWorld().children.erase(it);

--- a/engine/src/SceneViewer.cpp
+++ b/engine/src/SceneViewer.cpp
@@ -101,7 +101,7 @@ void SceneViewer::initializePickingFBO()
 
 void SceneViewer::initializeInputs()
 {
-    GPE::InputComponent& input = cameraOwner.addComponent<GPE::InputComponent>();
+    GPE::InputComponent& input = cameraOwner->addComponent<GPE::InputComponent>();
 
     input.bindAction("up",       EKeyMode::KEY_DOWN,     "Editor", &freeFly, "up");
     input.bindAction("down",     EKeyMode::KEY_DOWN,     "Editor", &freeFly, "down");
@@ -147,9 +147,9 @@ SceneViewer::SceneViewer(GPE::Scene& viewed, int width_, int height_)
 SceneViewer::~SceneViewer()
 {
     pScene->getWorld().children.erase(it);
-    cameraOwner.destroyUniqueComponentNow<Camera>();
-    cameraOwner.destroyUniqueComponentNow<FreeFly>();
-    cameraOwner.destroyUniqueComponentNow<InputComponent>();
+    cameraOwner->destroyUniqueComponentNow<Camera>();
+    cameraOwner->destroyUniqueComponentNow<FreeFly>();
+    cameraOwner->destroyUniqueComponentNow<InputComponent>();
 
     glDeleteFramebuffers(1, &framebufferID);
     glDeleteTextures(1, &textureID);
@@ -211,7 +211,6 @@ void SceneViewer::resize(int width_, int height_)
     glBindRenderbuffer(GL_RENDERBUFFER, depthStencilID);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_STENCIL, width, height);
 
-    camera.setAspect(Camera::computeAspect(width, height));
 
     // ==== Update selection framebuffer ====
     // Low sampling (we don't need 4K texture to select element)
@@ -224,6 +223,9 @@ void SceneViewer::resize(int width_, int height_)
 
     glBindRenderbuffer(GL_RENDERBUFFER, FBOIDdepthID);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, FBOIDwidth, FBOIDheight);
+
+    // ==== Update the camera ==== // TODO: does not work
+    camera.setAspect(Camera::computeAspect(width, height));
 }
 
 void SceneViewer::bindScene(Scene& scene)

--- a/engine/src/SceneViewer.cpp
+++ b/engine/src/SceneViewer.cpp
@@ -57,11 +57,10 @@ void SceneViewer::initializeFramebuffer()
     }
 }
 
-
 void SceneViewer::initializePickingFBO()
 {
     // low sampling (we don't need 4K texture to select element)
-    FBOIDwidth  = static_cast<int>(ceilf(width  * INV_DOWN_SAMPLING_COEF));
+    FBOIDwidth  = static_cast<int>(ceilf(width * INV_DOWN_SAMPLING_COEF));
     FBOIDheight = static_cast<int>(ceilf(height * INV_DOWN_SAMPLING_COEF));
 
     // Create FBO
@@ -117,28 +116,28 @@ void SceneViewer::initializeInputs()
 
 // ========================== Public methods ==========================
 SceneViewer::SceneViewer(GPE::Scene& viewed, int width_, int height_)
-    : cameraOwner    {viewed, {"Editor camera", {}, &viewed.getWorld()}},
-      freeFly        {cameraOwner.addComponent<FreeFly>()},
-      camera         {cameraOwner.addComponent<Camera>(Camera::PerspectiveCreateArg{width_ / (float)height_, .001f, 1000.f, 90.f})},
-      pScene         {&viewed},
-      it             {viewed.getWorld().children.emplace(viewed.getWorld().children.end(), &cameraOwner)},
-      textureID      {0u},
-      depthStencilID {0u},
-      framebufferID  {0u},
-      FBOIDtextureID {0u},
-      FBOIDdepthID   {0u},
+    : cameraOwner       {viewed, {"Editor camera", {}, &viewed.getWorld()}}, freeFly{cameraOwner.addComponent<FreeFly>()},
+      camera            {cameraOwner.addComponent<Camera>(Camera::PerspectiveCreateArg{width_ / (float)height_, .001f, 1000.f, 90.f})},
+      pScene            {&viewed},
+      it                {viewed.getWorld().children.emplace(viewed.getWorld().children.end(), &cameraOwner)},
+      textureID         {0u},
+      depthStencilID    {0u},
+      framebufferID     {0u},
+      FBOIDtextureID    {0u},
+      FBOIDdepthID      {0u},
       FBOIDframebufferID{0u},
-      FBOIDwidth     {static_cast<int>(ceilf(width_ * INV_DOWN_SAMPLING_COEF))},
-      FBOIDheight    {static_cast<int>(ceilf(height_ * INV_DOWN_SAMPLING_COEF))},
-      width          {width_},
-      height         {height_},
-      m_captureInputs{false}
+      FBOIDwidth        {static_cast<int>(ceilf(width_ * INV_DOWN_SAMPLING_COEF))},
+      FBOIDheight       {static_cast<int>(ceilf(height_ * INV_DOWN_SAMPLING_COEF))},
+      width             {width_},
+      height            {height_},
+      m_captureInputs   {false}
 {
     Engine::getInstance()->resourceManager.add<Shader>("gameObjectIdentifier",
                                                        "./resources/shaders/vGameObjectIdentifier.vs",
                                                        "./resources/shaders/fGameObjectIdentifier.fs");
     initializeFramebuffer();
     initializePickingFBO();
+    initializeInputs();
 
     freeFly.enableFixedUpdate(m_captureInputs);
     freeFly.setActive(m_captureInputs);
@@ -146,19 +145,10 @@ SceneViewer::SceneViewer(GPE::Scene& viewed, int width_, int height_)
 
 SceneViewer::~SceneViewer()
 {
-    // TODO: unbind actions
-    // InputComponent& input = owner.addComponent<InputComponent>();
-    // input.unbindAction("up");
-    // input.unbindAction("down");
-    // input.unbindAction("right");
-    // input.unbindAction("left");
-    // input.unbindAction("forward");
-    // input.unbindAction("backward");
-    // input.unbindAction("sprint");
-
-    //cameraOwner.destroyUniqueComponentNow<Camera>();
-    //cameraOwner.destroyUniqueComponentNow<FreeFly>();
     pScene->getWorld().children.erase(it);
+    cameraOwner.destroyUniqueComponentNow<Camera>();
+    cameraOwner.destroyUniqueComponentNow<FreeFly>();
+    cameraOwner.destroyUniqueComponentNow<InputComponent>();
 
     glDeleteFramebuffers(1, &framebufferID);
     glDeleteTextures(1, &textureID);
@@ -168,7 +158,6 @@ SceneViewer::~SceneViewer()
     glDeleteTextures(1, &FBOIDtextureID);
     glDeleteRenderbuffers(1, &FBOIDdepthID);
 }
-
 
 unsigned int SceneViewer::getHoveredGameObjectID() const
 {
@@ -180,29 +169,28 @@ unsigned int SceneViewer::getHoveredGameObjectID() const
 
     glBindFramebuffer(GL_FRAMEBUFFER, FBOIDframebufferID);
 
-    SceneRenderSystem renderSys{pScene->sceneRenderer};
+    RenderSystem renderSys{pScene->sceneRenderer};
     renderSys.draw(Engine::getInstance()->resourceManager, renderSys.gameObjectIdentifierPipeline());
 
     // Find the hovered game object, if any
-    unsigned int pixel = 0u;
-    int x, y;
+    GLuint pixel = 0u;
+    GLint  x, y;
 
     { // Find the coordinates of the pixel to read
         const ImVec2 currentScreenStart = ImGui::GetCursorScreenPos();
         const ImVec2 cursPos            = ImGui::GetMousePos();
-        const ImVec2 cursorRelativePos   {ceilf((cursPos.x - currentScreenStart.x)),
-                                          ceilf((cursPos.y - currentScreenStart.y))};
+        const ImVec2 cursorRelativePos  {ceilf((cursPos.x - currentScreenStart.x)),
+                                         ceilf((cursPos.y - currentScreenStart.y))};
 
         x = static_cast<GLint>(cursorRelativePos.x * INV_DOWN_SAMPLING_COEF);
         y = static_cast<GLint>((static_cast<float>(height) - cursorRelativePos.y) * INV_DOWN_SAMPLING_COEF);
     }
-    
+
     glReadPixels(x, y, 1u, 1u, GL_RED_INTEGER, GL_UNSIGNED_INT, &pixel);
     glBindFramebuffer(GL_FRAMEBUFFER, 0u);
 
-    return pixel;
+    return static_cast<unsigned int>(pixel);
 }
-
 
 void SceneViewer::resize(int width_, int height_)
 {
@@ -222,12 +210,11 @@ void SceneViewer::resize(int width_, int height_)
     glBindRenderbuffer(GL_RENDERBUFFER, depthStencilID);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_STENCIL, width, height);
 
-    camera.setAspect(width / (float)height);
-
+    camera.setAspect(Camera::computeAspect(width, height));
 
     // ==== Update selection framebuffer ====
     // Low sampling (we don't need 4K texture to select element)
-    FBOIDwidth  = static_cast<int>(ceilf(width_  * INV_DOWN_SAMPLING_COEF));
+    FBOIDwidth  = static_cast<int>(ceilf(width_ * INV_DOWN_SAMPLING_COEF));
     FBOIDheight = static_cast<int>(ceilf(height_ * INV_DOWN_SAMPLING_COEF));
 
     // Resize texture and depth buffers
@@ -247,7 +234,7 @@ void SceneViewer::bindScene(Scene& scene)
 
     { // Move cameraOwner to the other scene
         // Transfer ownership of &cameraOwner to the new scene
-        using iterator = GameObject::Children::iterator;
+        using iterator       = GameObject::Children::iterator;
         const iterator newIt = scene.getWorld().children.emplace(scene.getWorld().children.end(), *it);
 
         // Update the previous scene and the iterator to cameraOwner's parent's children list
@@ -259,13 +246,13 @@ void SceneViewer::bindScene(Scene& scene)
     camera.moveTowardScene(scene);
     cameraOwner.setParent(scene.getWorld());
     cameraOwner.pOwnerScene = &scene;
-    pScene = &scene;
+    pScene                  = &scene;
 }
 
 void SceneViewer::render() const
 {
     camera.updateView();
-    
+
     glBindFramebuffer(GL_FRAMEBUFFER, framebufferID);
     glViewport(0, 0, width, height);
 
@@ -278,7 +265,7 @@ void SceneViewer::captureInputs(bool shouldCapture)
         return;
 
     m_captureInputs = shouldCapture;
-    
+
     freeFly.enableUpdate(shouldCapture);
     freeFly.setActive(shouldCapture);
 }

--- a/launcher/gameStartup.cpp
+++ b/launcher/gameStartup.cpp
@@ -41,7 +41,7 @@ GameStartup::GameStartup()
     gameFunctionsPtr.render = [&]() {
         int h, w;
         GPE::Engine::getInstance()->window.getSize(w, h);
-        m_game->setViewport(0, 0, w, h);
+        m_game->setViewport(.0f, .0f, float(w), float(h));
 
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glViewport(0, 0, w, h);

--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -1,5 +1,4 @@
 ﻿#define GLFW_INCLUDE_NONE
-#define GLFW_DLL
 #include "Engine/Core/Debug/Log.hpp"
 #include "GameStartup.hpp"
 

--- a/projects/GPGame/imgui.ini
+++ b/projects/GPGame/imgui.ini
@@ -1,11 +1,11 @@
 [Window][DockSpaceViewport_11111111]
 Pos=0,19
-Size=1167,989
+Size=1920,998
 Collapsed=0
 
 [Window][Explorer]
-Pos=140,593
-Size=834,415
+Pos=228,774
+Size=1361,243
 Collapsed=0
 DockId=0x00000002,0
 
@@ -15,43 +15,51 @@ Size=400,400
 Collapsed=0
 
 [Window][Game controls]
-Pos=140,19
-Size=834,32
+Pos=228,19
+Size=1361,32
 Collapsed=0
 DockId=0x00000007
 
 [Window][World]
-Pos=140,53
-Size=834,538
+Pos=228,53
+Size=681,719
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][Scene Graph]
 Pos=0,19
-Size=138,989
+Size=226,998
 Collapsed=0
 DockId=0x00000005,0
 
 [Window][Inspector]
-Pos=976,19
-Size=191,989
+Pos=1591,19
+Size=329,998
 Collapsed=0
 DockId=0x00000004,0
 
 [Window][Game view]
-Pos=140,53
-Size=834,538
+Pos=911,53
+Size=678,719
 Collapsed=0
-DockId=0x00000001,1
+DockId=0x0000000A,0
+
+[Window][Scene editor (World)]
+Pos=228,53
+Size=681,719
+Collapsed=0
+DockId=0x00000009,0
 
 [Docking][Data]
-DockSpace         ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1167,989 Split=X
-  DockNode        ID=0x00000003 Parent=0x8B93E3BD SizeRef=1603,998 Split=X
-    DockNode      ID=0x00000005 Parent=0x00000003 SizeRef=228,998 Selected=0xB31A7869
-    DockNode      ID=0x00000006 Parent=0x00000003 SizeRef=1373,998 Split=Y
-      DockNode    ID=0x00000007 Parent=0x00000006 SizeRef=1920,32 NoTabBar=1 Selected=0xCDCD34E8
-      DockNode    ID=0x00000008 Parent=0x00000006 SizeRef=1920,964 Split=Y
-        DockNode  ID=0x00000001 Parent=0x00000008 SizeRef=1920,547 CentralNode=1 Selected=0xEC9B321F
-        DockNode  ID=0x00000002 Parent=0x00000008 SizeRef=1920,415 Selected=0x1E89CEB8
-  DockNode        ID=0x00000004 Parent=0x8B93E3BD SizeRef=315,998 Selected=0xF02CD328
+DockSpace           ID=0x8B93E3BD Window=0xA787BDB4 Pos=0,19 Size=1920,998 Split=X
+  DockNode          ID=0x00000003 Parent=0x8B93E3BD SizeRef=1589,998 Split=X
+    DockNode        ID=0x00000005 Parent=0x00000003 SizeRef=226,998 Selected=0xB31A7869
+    DockNode        ID=0x00000006 Parent=0x00000003 SizeRef=1361,998 Split=Y
+      DockNode      ID=0x00000007 Parent=0x00000006 SizeRef=1920,32 NoTabBar=1 Selected=0xCDCD34E8
+      DockNode      ID=0x00000008 Parent=0x00000006 SizeRef=1920,964 Split=Y
+        DockNode    ID=0x00000001 Parent=0x00000008 SizeRef=1920,719 Split=X Selected=0x482D9AE9
+          DockNode  ID=0x00000009 Parent=0x00000001 SizeRef=681,719 CentralNode=1 Selected=0x482D9AE9
+          DockNode  ID=0x0000000A Parent=0x00000001 SizeRef=678,719 Selected=0xEC9B321F
+        DockNode    ID=0x00000002 Parent=0x00000008 SizeRef=1920,243 Selected=0x1E89CEB8
+  DockNode          ID=0x00000004 Parent=0x8B93E3BD SizeRef=329,998 Selected=0xF02CD328
 

--- a/projects/GPGame/include/Game.hpp
+++ b/projects/GPGame/include/Game.hpp
@@ -1,46 +1,50 @@
 ﻿#pragma once
 
-#include "Engine/Core/Game/AbstractGame.hpp"
-#include "Engine/Core/Rendering/Renderer/RendererGLFW_GL46.hpp"
-#include "Engine/Core/Rendering/Window/WindowGLFW.hpp"
-#include "Engine/ECS/System/BehaviourSystem.hpp"
-#include "Engine/ECS/System/InputManagerGLFW.hpp"
-#include "Engine/ECS/System/TimeSystem.hpp"
-#include "Engine/Engine.hpp"
-#include "Engine/Resources/Scene.hpp"
+#include <Engine/Core/Game/AbstractGame.hpp>
+#include <Engine/Resources/ResourcesManagerType.hpp>
 #include "GameApiMacros.hpp"
+
+struct GLFWwindow;
+
+namespace GPE
+{
+
+class Window;
+class Renderer;
+class TimeSystem;
+class InputManager;
+class BehaviourSystem;
+class SceneManager;
+}
 
 class Game final : public GPE::AbstractGame
 {
 protected:
-    GPE::Window&              win      = GPE::Engine::getInstance()->window;
-    GPE::Renderer&            ren      = GPE::Engine::getInstance()->renderer;
-    GPE::TimeSystem&          ts       = GPE::Engine::getInstance()->timeSystem;
-    GPE::InputManager&        iManager = GPE::Engine::getInstance()->inputManager;
-    GPE::BehaviourSystem&     bSys     = GPE::Engine::getInstance()->behaviourSystem;
-    GPE::ResourceManagerType& rm       = GPE::Engine::getInstance()->resourceManager;
-    GPE::SceneManager&        sm       = GPE::Engine::getInstance()->sceneManager;
+    GPE::Window&              win;
+    GPE::Renderer&            ren;
+    GPE::TimeSystem&          ts;
+    GPE::InputManager&        iManager;
+    GPE::BehaviourSystem&     bSys;
+    GPE::ResourceManagerType& rm;
+    GPE::SceneManager&        sm;
 
+    double FPLogDelay              = 1.;
+    float  m_x = .0f, m_y = .0f, m_w = .0f, m_h = .0f;
     int    fixedUpdateFrameCount   = 0;
     int    unFixedUpdateFrameCount = 0;
-    double FPLogDelay              = 1.;
-
-    float m_x = 0, m_y = 0, m_w = 0, m_h = 0;
 
 private:
-    virtual void update(double unscaledDeltaTime, double deltaTime) override final;
-
+    virtual void update     (double unscaledDeltaTime, double deltaTime)           override final;
     virtual void fixedUpdate(double fixedUnscaledDeltaTime, double fixedDeltaTime) override final;
-
-    virtual void render() override final;
+    virtual void render     ()                                                     override final;
 
 public:
     Game();
+    virtual ~Game() final;
 
     void initDearImGui(GLFWwindow* window);
-    void setViewport(float x, float y, float w, float h);
+    void setViewport  (float x, float y, float w, float h);
 
-    virtual ~Game() final;
 };
 
 /**

--- a/projects/GPGame/include/Game.hpp
+++ b/projects/GPGame/include/Game.hpp
@@ -15,7 +15,7 @@ class Game final : public GPE::AbstractGame
 {
 protected:
     GPE::BehaviourSystem&     bSys;
-    GPE::GameObject*          world;
+    GPE::GameObject&          world;
 
     double FPLogDelay              = 1.;
     float  m_x = .0f, m_y = .0f, m_w = .0f, m_h = .0f;

--- a/projects/GPGame/include/Game.hpp
+++ b/projects/GPGame/include/Game.hpp
@@ -1,32 +1,21 @@
 ﻿#pragma once
 
 #include <Engine/Core/Game/AbstractGame.hpp>
-#include <Engine/Resources/ResourcesManagerType.hpp>
 #include "GameApiMacros.hpp"
 
 struct GLFWwindow;
 
 namespace GPE
 {
-
-class Window;
-class Renderer;
-class TimeSystem;
-class InputManager;
 class BehaviourSystem;
-class SceneManager;
+class GameObject;
 }
 
 class Game final : public GPE::AbstractGame
 {
 protected:
-    GPE::Window&              win;
-    GPE::Renderer&            ren;
-    GPE::TimeSystem&          ts;
-    GPE::InputManager&        iManager;
     GPE::BehaviourSystem&     bSys;
-    GPE::ResourceManagerType& rm;
-    GPE::SceneManager&        sm;
+    GPE::GameObject*          world;
 
     double FPLogDelay              = 1.;
     float  m_x = .0f, m_y = .0f, m_w = .0f, m_h = .0f;

--- a/projects/GPGame/include/myFpsScript.hpp
+++ b/projects/GPGame/include/myFpsScript.hpp
@@ -28,11 +28,12 @@ private:
     RFKField(Serialize()) GPE::AudioComponent*      source     = nullptr;
     RFKField(Serialize()) GPE::CharacterController* controller = nullptr;
 
-    // Test to use a setter
+    /* Variable setter serialization example
     RFKField(Inspect("setPrintHello"))
     bool printHello = false;
 
     void setPrintHello(bool p);
+    */
 
 public:
     MyFpsScript           (GPE::GameObject& owner)   noexcept;

--- a/projects/GPGame/include/myFpsScript.hpp
+++ b/projects/GPGame/include/myFpsScript.hpp
@@ -1,262 +1,68 @@
 ﻿/*
  * Copyright (C) 2021 Amara Sami, Dallard Thomas, Nardone William, Six Jonathan
  * This file is subject to the LGNU license terms in the LICENSE file
- *	found in the top-level directory of this distribution.
+ * found in the top-level directory of this distribution.
  */
 
 #pragma once
-#define GLFW_INCLUDE_NONE
-#define GLFW_DLL
-#include "GLFW/glfw3.h"
-#include <Engine/ECS/Component/AudioComponent.hpp>
+
 #include <Engine/ECS/Component/BehaviourComponent.hpp>
-#include <Engine/ECS/Component/InputComponent.hpp>
-#include <Engine/ECS/Component/Physics/CharacterController/CharacterController.hpp>
-#include <Engine/ECS/System/InputManagerGLFW.hpp>
-#include <Engine/ECS/System/PhysXSystem.hpp>
-#include <Engine/Engine.hpp>
-#include <Engine/Intermediate/GameObject.hpp>
-#include <Engine/Resources/Wave.hpp>
-#include <Windows.h>
-
-#include "Engine/Core/Tools/ImGuiTools.hpp"
-#include <imgui.h>
-#include <imgui_internal.h>
-
-// Generated
 #include "Generated/myFpsScript.rfk.h"
+
+namespace GPE
+{
+
+class InputComponent;
+class AudioComponent;
+class CharacterController;
+
+}
 
 namespace GPG RFKNamespace()
 {
-    class RFKClass(Inspect(), ComponentGen, Serialize()) MyFpsScript : public GPE::BehaviourComponent
-    {
-    public:
-        inline MyFpsScript(GPE::GameObject & owner) noexcept
-            : GPE::BehaviourComponent(owner)
-        {
 
-            input = &owner.addComponent<GPE::InputComponent>();
-            source = &owner.addComponent<GPE::AudioComponent>();
-            controller = &owner.addComponent<GPE::CharacterController>();
+class RFKClass(Inspect(), ComponentGen, Serialize()) MyFpsScript : public GPE::BehaviourComponent
+{
+private:
+    RFKField(Serialize()) GPE::InputComponent*      input      = nullptr;
+    RFKField(Serialize()) GPE::AudioComponent*      source     = nullptr;
+    RFKField(Serialize()) GPE::CharacterController* controller = nullptr;
 
-            enableFixedUpdate(true);
-            enableOnGUI(true);
-            input->bindAction("jump", EKeyMode::KEY_DOWN, "game01", this, "jump");
-            input->bindAction("right", EKeyMode::KEY_DOWN, "game01", this, "right");
-            input->bindAction("left", EKeyMode::KEY_DOWN, "game01", this, "left");
-            input->bindAction("forward", EKeyMode::KEY_DOWN, "game01", this, "forward");
-            input->bindAction("back", EKeyMode::KEY_DOWN, "game01", this, "back");
-            input->bindAction("exitGame01", EKeyMode::KEY_PRESSED, "game01", this, "leave");
-            input->bindAction("exitGame02", EKeyMode::KEY_PRESSED, "game02", this, "leave");
-            input->bindAction("sprintStart", EKeyMode::KEY_PRESSED, "game01", this, "sprintStart");
-            input->bindAction("sprintEnd", EKeyMode::KEY_RELEASED, "game01", this, "sprintEnd");
-            input->bindAction("growUpCollider", EKeyMode::KEY_DOWN, "game01", this, "growUpSphereCollider");
-            input->bindAction("growDownCollider", EKeyMode::KEY_DOWN, "game01", this, "growDownSphereCollider");
-            input->bindAction("swapInputModeToGame01", EKeyMode::KEY_PRESSED, "game02", this, "swapInputModeToGame01");
-            input->bindAction("swapInputModeToGame02", EKeyMode::KEY_PRESSED, "game01", this, "swapInputModeToGame02");
+    // Test to use a setter
+    RFKField(Inspect("setPrintHello"))
+    bool printHello = false;
 
-            GPE::Wave testSound("./resources/sounds/RickRoll.wav", "RICKROLL");
-            GPE::Wave testSound2("./resources/sounds/YMCA.wav", "YMCA");
-            GPE::Wave testSound3("./resources/sounds/E_Western.wav", "Western");
+    void setPrintHello(bool p);
 
-            GPE::SourceSettings sourceSettings;
-            sourceSettings.pitch = 1.f;
-            sourceSettings.loop  = AL_TRUE;
+public:
+    MyFpsScript           (GPE::GameObject& owner)   noexcept;
+    MyFpsScript           ()                         noexcept = default;
+    MyFpsScript           (const MyFpsScript& other) noexcept = delete;
+    MyFpsScript           (MyFpsScript && other)     noexcept = delete;
+    virtual ~MyFpsScript  ()                         noexcept;
 
-            source->setSound("Western", "Western", sourceSettings);
-            source->playSound("Western");
+    MyFpsScript& operator=(MyFpsScript const& other) noexcept = delete;
+    MyFpsScript& operator=(MyFpsScript&& other)      noexcept = delete;
 
-            controller->setHasGravity(true);
-            controller->setSpeed(1.f);
-            controller->setMouseSpeed(0.0025f);
-            controller->setGravity(0.1f);
-        }
+public:
+    RFKMethod() void jump                  ();
+    RFKMethod() void forward               ();
+    RFKMethod() void backward              ();
+    RFKMethod() void left                  ();
+    RFKMethod() void right                 ();
+    RFKMethod() void leave                 ();
+    RFKMethod() void sprintStart           ();
+    RFKMethod() void sprintEnd             ();
+    //RFKMethod() void growUpSphereCollider  ();
+    //RFKMethod() void growDownSphereCollider();
+    RFKMethod() void swapInputModeToGame01 ();
+    RFKMethod() void swapInputModeToGame02 ();
 
-        //MyFpsScript() noexcept : GPE::BehaviourComponent()
-        //{
-        //    //enableFixedUpdate(true);
-        //}
-        MyFpsScript() noexcept                         = default;
-        MyFpsScript(const MyFpsScript& other) noexcept = delete;
-        MyFpsScript(MyFpsScript && other) noexcept     = delete;
-        virtual ~MyFpsScript() noexcept                
-        {
-            enableFixedUpdate(false);
-        }
+    void rotate                            (const GPM::Vec2& deltaDisplacement);
+    void onGUI                             () final;
+    void fixedUpdate                       (float deltaTime) final;
 
-        MyFpsScript& operator=(MyFpsScript const& other) noexcept = delete;
-        MyFpsScript& operator=(MyFpsScript&& other) noexcept = delete;
+    MyFpsScript_GENERATED
+};
 
-    private:
-        RFKField(Serialize()) GPE::InputComponent*      input      = nullptr;
-        RFKField(Serialize()) GPE::AudioComponent*      source     = nullptr;
-        RFKField(Serialize()) GPE::CharacterController* controller = nullptr;
-
-        // Test to use a setter
-        RFKField(Inspect("setPrintHello")) 
-        bool printHello = false;
-
-        void setPrintHello(bool p)
-        {
-            if (printHello != p) // Called everytime if no if 
-            {
-                printHello = p;
-
-                if (printHello)
-                {
-                    GPE::Log::getInstance()->log("Hello world!");
-                }
-                else
-                {
-                    GPE::Log::getInstance()->log("Set me to true!");
-                }
-            }
-        }
-
-    public:
-
-        void rotate(const GPM::Vec2& deltaDisplacement)
-        {
-            if (deltaDisplacement.length() > 0.4f)
-            {
-                getOwner().getTransform().setRotation(
-                    getOwner().getTransform().getSpacialAttribut().rotation *
-                    GPM::Quaternion::angleAxis(-deltaDisplacement.y * controller->getMouseSpeed(), GPM::Vec3::right()));
-                getOwner().getTransform().setRotation(
-                    GPM::Quaternion::angleAxis(-deltaDisplacement.x * controller->getMouseSpeed(), GPM::Vec3::up()) *
-                    getOwner().getTransform().getSpacialAttribut().rotation);
-            }
-        }
-
-        RFKMethod() inline void jump()
-        {
-            if (controller->getJumping() == false)
-            {
-                controller->addForce(GPM::Vec3::up() * 3.f);
-                controller->setJumping(true);
-            }
-        }
-
-        RFKMethod() inline void forward()
-        {
-            GPM::Vec3 vec = getOwner().getTransform().getVectorForward();
-            vec.y         = 0;
-            controller->move(-vec);
-            // rigidbody.rigidbody->addForce(vec * -speed, physx::PxForceMode::eFORCE);
-        }
-
-        RFKMethod() inline void back()
-        {
-            GPM::Vec3 vec = getOwner().getTransform().getVectorForward();
-            vec.y         = 0;
-            controller->move(vec);
-            // rigidbody.rigidbody->addForce(vec * speed, physx::PxForceMode::eFORCE);
-        }
-
-        RFKMethod() inline void left()
-        {
-            GPM::Vec3 vec = getOwner().getTransform().getVectorRight();
-            vec.y         = 0;
-            controller->move(-vec);
-            // rigidbody.rigidbody->addForce(vec * -speed, physx::PxForceMode::eFORCE);
-        }
-
-        RFKMethod() inline void right()
-        {
-            GPM::Vec3 vec = getOwner().getTransform().getVectorRight();
-            vec.y         = 0;
-            controller->move(vec);
-            // rigidbody.rigidbody->addForce(vec * speed, physx::PxForceMode::eFORCE);
-        }
-
-        RFKMethod() inline void leave()
-        {
-            exit(666);
-        }
-
-        RFKMethod() inline void sprintStart()
-        {
-            controller->setSpeed(controller->getSpeed() * 2.f);
-        }
-
-        RFKMethod() inline void sprintEnd()
-        {
-            controller->setSpeed(controller->getSpeed() / 2.f);
-        }
-
-        RFKMethod() inline void growUpSphereCollider()
-        {
-            // collider.setRadius(collider.getRadius() + 1);
-        }
-
-        RFKMethod() inline void growDownSphereCollider()
-        {
-            // collider.setRadius(collider.getRadius() - 1);
-        }
-
-        void onGUI() final
-        {
-            static float ratio = 0.08f;
-
-            ImGui::DragFloat("Ratio", &ratio, 0.01f, 0.f, 1.f);
-
-            ImVec2 size = {ImGui::GetWindowSize().x * ratio, ImGui::GetWindowSize().y * ratio};
-
-            ImGui::SetNextElementLayout(0.f, 0.f, size, ImGui::EHAlign::Left, ImGui::EVAlign::Top);
-            ImGui::Button("Top/Left", size);
-
-            ImGui::SetNextElementLayout(0.5, 0.f, size, ImGui::EHAlign::Middle, ImGui::EVAlign::Top);
-            ImGui::Button("Top", size);
-
-            ImGui::SetNextElementLayout(1.f, 0.f, size, ImGui::EHAlign::Right, ImGui::EVAlign::Top);
-            ImGui::Button("Top/Right", size);
-
-            ImGui::SetNextElementLayout(0.f, 0.5f, size, ImGui::EHAlign::Left);
-            ImGui::Button("Mid/Left", size);
-
-            ImGui::SetNextElementLayout(0.5f, 0.5f, size);
-            ImGui::Button("Mid", size);
-
-            ImGui::SetNextElementLayout(1.f, 0.5f, size, ImGui::EHAlign::Right);
-            ImGui::Button("Mid/Right", size);
-
-            ImGui::SetNextElementLayout(0.f, 1.f, size, ImGui::EHAlign::Left, ImGui::EVAlign::Bottom);
-            ImGui::Button("Bot/Left", size);
-
-            ImGui::SetNextElementLayout(0.5f, 1.f, size, ImGui::EHAlign::Middle, ImGui::EVAlign::Bottom);
-            ImGui::Button("Bot", size);
-
-            ImGui::SetNextElementLayout(1.f, 1.f, size, ImGui::EHAlign::Right, ImGui::EVAlign::Bottom);
-            ImGui::Button("Bot/Right", size);
-        }
-
-        RFKMethod() void swapInputModeToGame01()
-        {
-            GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
-
-            iManager.setInputMode("game01");
-            iManager.setCursorTrackingState(true);
-            iManager.setCursorLockState(true);
-        }
-
-        RFKMethod() void swapInputModeToGame02()
-        {
-            GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
-
-            iManager.setInputMode("game02");
-            iManager.setCursorTrackingState(false);
-            iManager.setCursorLockState(false);
-        }
-
-        void fixedUpdate(float deltaTime) final
-        {
-            if (GPE::Engine::getInstance()->inputManager.getInputMode() == "game01")
-            {
-                rotate(GPE::Engine::getInstance()->inputManager.getCursor().deltaPos);
-            }
-            controller->update(deltaTime);
-        }
-
-        MyFpsScript_GENERATED
-    };
-} // namespace )
+} // namespace GPG

--- a/projects/GPGame/include/myFpsScript.hpp
+++ b/projects/GPGame/include/myFpsScript.hpp
@@ -56,12 +56,10 @@ public:
     RFKMethod() void sprintEnd             ();
     //RFKMethod() void growUpSphereCollider  ();
     //RFKMethod() void growDownSphereCollider();
-    RFKMethod() void swapInputModeToGame01 ();
-    RFKMethod() void swapInputModeToGame02 ();
 
     void rotate                            (const GPM::Vec2& deltaDisplacement);
     void onGUI                             () final;
-    void fixedUpdate                       (float deltaTime) final;
+    void fixedUpdate                       (double deltaTime) final;
 
     MyFpsScript_GENERATED
 };

--- a/projects/GPGame/include/myScript.hpp
+++ b/projects/GPGame/include/myScript.hpp
@@ -111,7 +111,7 @@ namespace GPG RFKNamespace()
             speed = sprintSpeed;
         }
 
-        void update(float deltaTime) final
+        void update(double deltaTime) final
         {
             speed = defaultSpeed;
 

--- a/projects/GPGame/src/game.cpp
+++ b/projects/GPGame/src/game.cpp
@@ -125,11 +125,12 @@ void loadTree(GameObject& parent, ResourceManagerType& resourceManager, unsigned
     for (size_t i = 0; i < number; ++i)
     {
         treeGameObject.name                         = "Tree" + std::to_string(i);
-        treeGameObject.transformArg.position.x      = randRanged<float>(-1000.f, 1000.f);
-        treeGameObject.transformArg.position.z      = randRanged<float>(-1000.f, 1000.f);
+        treeGameObject.transformArg.position.x      = randRanged<float>(-100.f, 100.f);
+        treeGameObject.transformArg.position.z      = randRanged<float>(-100.f, 100.f);
         treeGameObject.transformArg.eulerRotation.y = randRanged<float>(360.f * 3.14f / 180.f);
 
-        treeGameObject.transformArg.scale = {randRanged<float>(4.f, 8.f), randRanged<float>(4.f, 8.f),
+        treeGameObject.transformArg.scale = {randRanged<float>(4.f, 8.f),
+                                             randRanged<float>(4.f, 8.f),
                                              randRanged<float>(4.f, 8.f)};
 
         GameObject& treeGO = treeContener.addChild(treeGameObject);
@@ -237,10 +238,10 @@ Game::Game()
 
     ground.addComponent<Model>(modelArg2);*/
     // loadSkyboxResource(rm);
-    // loadTreeResource(rm);
+    loadTreeResource(rm);
 
     // loadSkyBox(sm.getCurrentScene()->getWorld(), rm);
-    // loadTree(sm.getCurrentScene()->getWorld(), rm, 100);
+    loadTree(sm.getCurrentScene()->getWorld(), rm, 100);
 
     ts.addScaledTimer(
         FPLogDelay,

--- a/projects/GPGame/src/game.cpp
+++ b/projects/GPGame/src/game.cpp
@@ -1,70 +1,51 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #define GLFW_INCLUDE_NONE
 
-#include "Game.hpp"
-
-#include "Engine/Resources/Script/FreeFly.hpp"
-#include "Engine/ECS/Component/AudioComponent.hpp"
-#include "Engine/ECS/Component/InputComponent.hpp"
-#include "Engine/Resources/Scene.hpp"
-#include "Engine/ECS/Component/Physics/CharacterController/CharacterController.hpp"
-#include "myFpsScript.hpp"
-#include "Engine/Core/Debug/Assert.hpp"
-#include "Engine/Core/Debug/Log.hpp"
-#include "Engine/Core/Parsers/ObjParser.hpp"
-#include "Engine/Core/Rendering/Renderer/RendererGLFW_GL46.hpp"
-#include "Engine/Core/Rendering/Window/WindowGLFW.hpp"
-#include "Engine/ECS/Component/Camera.hpp"
-#include "Engine/ECS/Component/InputComponent.hpp"
-#include "Engine/ECS/Component/Light/DirectionalLight.hpp"
-#include "Engine/ECS/Component/Light/PointLight.hpp"
-#include "Engine/ECS/Component/Model.hpp"
-#include "Engine/ECS/Component/TransformComponent.hpp"
-#include "Engine/ECS/System/BehaviourSystem.hpp"
-#include "Engine/ECS/System/InputManagerGLFW.hpp"
-#include "Engine/ECS/System/TimeSystem.hpp"
-#include "Engine/Engine.hpp"
-#include "Engine/Intermediate/GameObject.hpp"
-#include "Engine/Resources/Material.hpp"
-#include "Engine/Resources/Mesh.hpp"
-#include "Engine/Resources/ResourcesManagerType.hpp"
-#include "Engine/Resources/Shader.hpp"
-#include "Engine/Resources/Texture.hpp"
-#include <Engine/ECS/Component/Physics/Collisions/BoxCollider.hpp>
-#include <Engine/ECS/Component/Physics/Collisions/SphereCollider.hpp>
+#include <Game.hpp>
 #include <myFpsScript.hpp>
 
-#include "Engine/Resources/Importer/Importer.hpp"
+#include <Engine/ECS/Component/Camera.hpp>
+#include <Engine/ECS/Component/Light/DirectionalLight.hpp>
+#include <Engine/ECS/Component/Light/PointLight.hpp>
+#include <Engine/ECS/Component/Physics/Collisions/BoxCollider.hpp>
+#include <Engine/ECS/Component/Physics/Collisions/SphereCollider.hpp>
+#include <Engine/Engine.hpp>
+#include <Engine/Resources/Importer/Importer.hpp>
+#include <Engine/Resources/Script/FreeFly.hpp>
+
+#include <GPM/Random.hpp>
 
 // Third_party
-#include <glad/glad.h> //In first
 #include <glfw/glfw3.h>
 
-#include "imgui/imgui_internal.h"
+#include <imgui/imgui_internal.h>
 #include <imgui/backends/imgui_impl_glfw.h>
 #include <imgui/backends/imgui_impl_opengl3.h>
 #include <imgui/imgui.h>
 
 using namespace GPE;
 using namespace GPM;
+using namespace GPM::Random;
 
 void Game::update(double unscaledDeltaTime, double deltaTime)
 {
     ++unFixedUpdateFrameCount;
 
-    bSys.update(static_cast<float>(deltaTime));
-    sm.getCurrentScene()->getWorld().updateSelfAndChildren();
+    bSys.update(float(deltaTime));
+    world->updateSelfAndChildren();
 }
 
 void Game::fixedUpdate(double fixedUnscaledDeltaTime, double fixedDeltaTime)
 {
-    GPE::Engine::getInstance()->physXSystem.advance(static_cast<float>(fixedDeltaTime));
     ++fixedUpdateFrameCount;
-    bSys.fixedUpdate(static_cast<float>(fixedDeltaTime));
+
+    GPE::Engine::getInstance()->physXSystem.advance(float(fixedDeltaTime));
+    bSys.fixedUpdate(float(fixedDeltaTime));
 }
 
 void Game::render()
 {
+    // TODO: Put in-game UI in a module
     // UI code can be easly move in update because it's not real render function. It however her for simplicity
     // Initialize a new frame
     ImGui_ImplOpenGL3_NewFrame();
@@ -76,7 +57,7 @@ void Game::render()
     ImGui::NewFrame();
 
     ImGui::SetNextWindowSize({m_w, m_h});
-    ImGui::SetNextWindowPos({0, 0});
+    ImGui::SetNextWindowPos({.0f, .0f});
 
     ImGui::Begin("UI", nullptr, ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration);
 
@@ -110,12 +91,14 @@ extern "C" void destroyGameInstance(GPE::AbstractGame* game)
     delete game;
 }
 
-void loadTreeResource(ResourceManagerType& resourceManager)
+void loadTreeResource()
 {
+    ResourceManagerType& rm = Engine::getInstance()->resourceManager;
     Model::CreateArg arg;
 
     SubModel subModel;
-    subModel.pShader   = resourceManager.get<Shader>("TextureWithLihghts");
+    subModel.pShader   = &rm.add<Shader>("TextureWithLihghts", "./resources/shaders/vTextureWithLight.vs",
+                                         "./resources/shaders/fTextureWithLight.fs", LIGHT_BLIN_PHONG);
     subModel.pMaterial = loadMaterialFile("./resources/meshs/Trank_bark.GPMaterial");
     subModel.pMesh     = loadMeshFile("./resources/meshs/g1.GPMesh");
 
@@ -126,50 +109,34 @@ void loadTreeResource(ResourceManagerType& resourceManager)
 
     arg.subModels.push_back(subModel);
 
-    resourceManager.add<Model::CreateArg>("TreeModel", arg);
+    rm.add<Model::CreateArg>("TreeModel", arg);
 }
 
-template <typename T = float>
-static auto randRanged(const T& max) -> std::enable_if_t<std::is_floating_point<T>::value, T>
+
+void loadTree(GameObject& parent, unsigned int number)
 {
-    return max <= std::numeric_limits<T>::epsilon() ? static_cast<T>(0)
-                                                    : static_cast<T>(rand()) / (static_cast<T>(RAND_MAX / max));
-}
+    const ResourceManagerType& rm = Engine::getInstance()->resourceManager;
+    GameObject::CreateArg forestArg{"Forest"};
 
-template <typename T = float>
-static auto randRanged(const T& min, const T& max) -> std::enable_if_t<std::is_floating_point<T>::value, T>
-{
-    return max - min <= std::numeric_limits<T>::epsilon()
-               ? max
-               : min + static_cast<T>(rand()) / (static_cast<T>(RAND_MAX / (max - min)));
-}
+    const Model::CreateArg& treeModelArg = *rm.get<Model::CreateArg>("TreeModel");
+    GameObject&             forest       = parent.addChild(forestArg);
 
-void loadTree(GameObject& parent, ResourceManagerType& resourceManager, unsigned int number)
-{
-    GameObject::CreateArg treeGameObject{"Trees", {{0.f, 0.f, 0.f}, {0.f, 0.f, 0.f}, {1.f, 1.f, 1.f}}};
-
-    GameObject&       treeContener = parent.addChild(treeGameObject);
-    Model::CreateArg& treeModelArg = *resourceManager.get<Model::CreateArg>("TreeModel");
-
-    /*Create tree with random size, position and rotation and add it on tre contener*/
-    for (size_t i = 0; i < number; ++i)
+    // Create trees with random sizes, positions and rotations and add them to the forest
+    for (unsigned int i = 0u; i < number; ++i)
     {
-        treeGameObject.name                         = "Tree" + std::to_string(i);
-        treeGameObject.transformArg.position.x      = randRanged<float>(-100.f, 100.f);
-        treeGameObject.transformArg.position.z      = randRanged<float>(-100.f, 100.f);
-        treeGameObject.transformArg.eulerRotation.y = randRanged<float>(360.f * 3.14f / 180.f);
+        forestArg.name                         = "Tree" + std::to_string(i);
+        forestArg.transformArg.position.x      = ranged<float>(-100.f, 100.f);
+        forestArg.transformArg.position.z      = ranged<float>(-100.f, 100.f);
+        forestArg.transformArg.eulerRotation.y = ranged<float>(TWO_PI);
+        forestArg.transformArg.scale           = {ranged<float>(4.f, 8.f)};
 
-        treeGameObject.transformArg.scale = {randRanged<float>(4.f, 8.f),
-                                             randRanged<float>(4.f, 8.f),
-                                             randRanged<float>(4.f, 8.f)};
-
-        GameObject& treeGO = treeContener.addChild(treeGameObject);
-        treeGO.addComponent<Model>(treeModelArg);
+        forest.addChild(forestArg).addComponent<Model>(treeModelArg);
     }
 }
 
-void loadSkyboxResource(ResourceManagerType& resourceManager)
+void loadSkyboxResource()
 {
+    ResourceManagerType& rm = Engine::getInstance()->resourceManager;
     Model::CreateArg arg;
 
     SubModel subModel;
@@ -180,16 +147,18 @@ void loadSkyboxResource(ResourceManagerType& resourceManager)
 
     arg.subModels.push_back(subModel);
 
-    resourceManager.add<Model::CreateArg>("SkyboxModel", arg);
+    rm.add<Model::CreateArg>("SkyboxModel", arg);
 }
 
-void loadSkyBox(GameObject& parent, ResourceManagerType& resourceManager)
+void loadSkyBox(GameObject& parent)
 {
-    GameObject::CreateArg skyboxArgGameObject{"Skybox", {{0.f, 0.f, 0.f}, {0.f, 0.f, 0.f}, {10.f, 10.f, 10.f}}};
+    const ResourceManagerType& rm = Engine::getInstance()->resourceManager;
+    const GameObject::CreateArg skyboxArgGameObject{"Skybox", {{.0f}, {.0f}, {10.f}}};
 
-    parent.addChild(skyboxArgGameObject).addComponent<Model>(*resourceManager.get<Model::CreateArg>("SkyboxModel"));
+    parent.addChild(skyboxArgGameObject).addComponent<Model>(*rm.get<Model::CreateArg>("SkyboxModel"));
 }
 
+// TODO: Put in-game UI in a module
 void Game::initDearImGui(GLFWwindow* window)
 {
     // Setup Dear ImGui context
@@ -209,6 +178,7 @@ void Game::setViewport(float x, float y, float w, float h)
     m_h = h;
 }
 
+// TODO: Put in-game UI in a module
 Game::~Game()
 {
     ImGui_ImplOpenGL3_Shutdown();
@@ -217,105 +187,131 @@ Game::~Game()
 }
 
 Game::Game()
+    : bSys {GPE::Engine::getInstance()->behaviourSystem},
+      world{nullptr}
 {
+    // ============= UI =============
+    // TODO: Put in-game UI in a module
     initDearImGui(GPE::Engine::getInstance()->window.getGLFWWindow());
 
-    sm.addEmpty("main");
-    sm.loadScene("main");
+    // ============ RNG =============
+    initSeed();
 
-    iManager.bindInput(GLFW_KEY_W, "forward");
-    iManager.bindInput(GLFW_KEY_S, "back");
-    iManager.bindInput(GLFW_KEY_A, "left");
-    iManager.bindInput(GLFW_KEY_D, "right");
-    iManager.bindInput(GLFW_KEY_SPACE, "jump");
-    iManager.bindInput(GLFW_KEY_LEFT_CONTROL, "down");
-    iManager.bindInput(GLFW_KEY_ESCAPE, "exitGame01");
-    iManager.bindInput(GLFW_KEY_ESCAPE, "exitGame02");
-    iManager.bindInput(GLFW_KEY_LEFT_SHIFT, "sprintStart");
-    iManager.bindInput(GLFW_KEY_LEFT_SHIFT, "sprintEnd");
-    iManager.bindInput(GLFW_KEY_KP_ADD, "growUpCollider");
-    iManager.bindInput(GLFW_KEY_KP_SUBTRACT, "growDownCollider");
-    iManager.bindInput(GLFW_KEY_X, "swapInputModeToGame01");
-    iManager.bindInput(GLFW_KEY_X, "swapInputModeToGame02");
+    // =========== Inputs ===========
+    { // Keys
+        InputManager& io = Engine::getInstance()->inputManager;
 
-    iManager.setInputMode("game02");
-    iManager.setCursorTrackingState(false);
+        io.bindInput(GLFW_KEY_W,            "forward");
+        io.bindInput(GLFW_KEY_S,            "backward");
+        io.bindInput(GLFW_KEY_A,            "left");
+        io.bindInput(GLFW_KEY_D,            "right");
+        io.bindInput(GLFW_KEY_SPACE,        "jump");
+        io.bindInput(GLFW_KEY_LEFT_CONTROL, "down");
+        io.bindInput(GLFW_KEY_ESCAPE,       "exitGame01");
+        io.bindInput(GLFW_KEY_ESCAPE,       "exitGame02");
+        io.bindInput(GLFW_KEY_LEFT_SHIFT,   "sprintStart");
+        io.bindInput(GLFW_KEY_LEFT_SHIFT,   "sprintEnd");
+        io.bindInput(GLFW_KEY_KP_ADD,       "growUpCollider");
+        io.bindInput(GLFW_KEY_KP_SUBTRACT,  "growDownCollider");
+        io.bindInput(GLFW_KEY_X,            "swapInputModeToGame01");
+        io.bindInput(GLFW_KEY_X,            "swapInputModeToGame02");
+        io.setInputMode("game02");
 
-    int x, y;
-    GPE::Engine::getInstance()->window.getSize(x, y);
+        // Cursor
+        io.setCursorTrackingState(false);
+    }
 
-    GameObject::CreateArg playerArg{"Player", TransformComponent::CreateArg{GPM::Vec3{0.f, 50.f, 0.f}}};
-    GameObject::CreateArg testPhysXArg{"TestphysX", TransformComponent::CreateArg{GPM::Vec3{0.f, 0.f, 50.f}}};
-    GameObject::CreateArg groundArg{"GroundArg", TransformComponent::CreateArg{GPM::Vec3{0.f, 0.f, 0.f}}};
+    // =========== Scene ===========
+    // Initialize world
+    world = &Engine::getInstance()->sceneManager.loadScene("main").getWorld();
+    
+    // Place content in the scene
+    GameObject* ground, * player, * testPhysX;
+    { 
+        const GameObject::CreateArg playerArg   {"Player",    TransformComponent::CreateArg{Vec3{0.f, 50.f, 0.f}}};
+        const GameObject::CreateArg testPhysXArg{"TestphysX", TransformComponent::CreateArg{Vec3{0.f, 0.f, 50.f}}};
+        const GameObject::CreateArg groundArg   {"GroundArg", TransformComponent::CreateArg{Vec3{0.f}}};
+    
+        // A ground, player, PhysX test
+        ground    = &world->addChild(groundArg);
+        player    = &world->addChild(playerArg);
+        testPhysX = &world->addChild(testPhysXArg);
+    }
 
-    Camera::PerspectiveCreateArg camCreateArg;
-    camCreateArg.aspect = Camera::computeAspect(900, 600);
+    // Skybox
+    loadSkyboxResource();
+    loadSkyBox(*world);
 
-    camCreateArg.farVal  = 3000;
-    camCreateArg.nearVal = 0.01f;
+    // Forest
+    loadTreeResource();
+    loadTree(*world, 100u);
 
-    PointLight::CreateArg lightArg{
-        {1.f, 1.f, 1.f, 0.1f}, {1.f, 1.f, 1.f, 1.0f}, {1.f, 1.f, 1.f, 1.f}, 1.0f, 0.0014f, 0.000007f};
+    { // Camera
+        Camera::PerspectiveCreateArg camCreateArg{"Player camera"};
+        player->addComponent<Camera>(camCreateArg);
+    }
 
-    rm.add<Shader>("TextureOnly", "./resources/shaders/vTextureOnly.vs", "./resources/shaders/fTextureOnly.fs",
-                   AMBIANTE_COLOR_ONLY);
-    rm.add<Shader>("TextureWithLihghts", "./resources/shaders/vTextureWithLight.vs",
-                   "./resources/shaders/fTextureWithLight.fs", LIGHT_BLIN_PHONG);
+    { // Light
+        const PointLight::CreateArg lightArg{{1.f, 1.f, 1.f, 0.1f}, {1.f, 1.f, 1.f, 1.0f},
+                                             {1.f, 1.f, 1.f, 1.f}, 1.0f, .0014f, 7e-6f};
+        player->addComponent<PointLight>(lightArg);
+    }
 
-    GameObject& ground    = sm.getCurrentScene()->getWorld().addChild(groundArg);
-    GameObject& player    = sm.getCurrentScene()->getWorld().addChild(playerArg);
-    GameObject& testPhysX = sm.getCurrentScene()->getWorld().addChild(testPhysXArg);
+    // Scripts
+    player->addComponent<GPG::MyFpsScript>();
 
-    player.addComponent<Camera>(camCreateArg);
-    player.addComponent<GPG::MyFpsScript>();
-    PointLight& light = player.addComponent<PointLight>(lightArg);
+    // Physics
+    { // ground
+        BoxCollider& box    = ground->addComponent<BoxCollider>();
+        RigidbodyStatic& rb = ground->addComponent<RigidbodyStatic>();
+        rb.collider         = &box;
+        box.isVisible       = true;
+        box.setDimensions({1000.f, 10.f, 1000.f});
+    }
 
-    testPhysX.addComponent<SphereCollider>();
-    testPhysX.getComponent<SphereCollider>()->isVisible = true;
-    testPhysX.getComponent<SphereCollider>()->setRadius(10.f);
-    testPhysX.addComponent<RigidbodyStatic>();
-    testPhysX.getComponent<RigidbodyStatic>()->collider = testPhysX.getComponent<SphereCollider>();
+    { // testPhysX
+        SphereCollider& sphere = testPhysX->addComponent<SphereCollider>();
+        sphere.isVisible = true;
+        sphere.setRadius(10.f);
+        testPhysX->addComponent<RigidbodyStatic>().collider = &sphere;
+    }
 
+    /*
     // FreeFly must be used to compile properly with GPGame.dll, to not be optimized out, for serialization.
     {
         rfk::Entity const* a = rfk::Database::getEntity(GPE::FreeFly::staticGetArchetype().id);
     }
+    
+    rm.add<Shader>("TextureOnly", "./resources/shaders/vTextureOnly.vs",
+                "./resources/shaders/fTextureOnly.fs", AMBIANTE_COLOR_ONLY);
 
-    /*Model::CreateArg modelArg;
+    Model::CreateArg modelArg;
     modelArg.subModels.emplace_back(SubModel{nullptr, Engine::getInstance()->resourceManager.get<Shader>("TextureOnly"),
                                              Engine::getInstance()->resourceManager.get<Material>("SkyboxMaterial"),
                                              Engine::getInstance()->resourceManager.get<Mesh>("Sphere")});
 
-    testPhysX.addComponent<Model>(modelArg);*/
+    testPhysX->addComponent<Model>(modelArg);
 
-    ground.addComponent<BoxCollider>();
-    ground.getComponent<BoxCollider>()->isVisible = true;
-    ground.getComponent<BoxCollider>()->setDimensions(Vec3{1000.f, 10.f, 1000.f});
-    ground.addComponent<RigidbodyStatic>();
-    ground.getComponent<RigidbodyStatic>()->collider = ground.getComponent<BoxCollider>();
-
-    /*Model::CreateArg modelArg2;
+    Model::CreateArg modelArg2;
     modelArg2.subModels.emplace_back(SubModel{nullptr,
-                                              Engine::getInstance()->resourceManager.get<Shader>("TextureOnly"),
-                                              Engine::getInstance()->resourceManager.get<Material>("SkyboxMaterial"),
-                                              Engine::getInstance()->resourceManager.get<Mesh>("CubeDebug")});
+                                                Engine::getInstance()->resourceManager.get<Shader>("TextureOnly"),
+                                                Engine::getInstance()->resourceManager.get<Material>("SkyboxMaterial"),
+                                                Engine::getInstance()->resourceManager.get<Mesh>("CubeDebug")});
 
-    ground.addComponent<Model>(modelArg2);*/
-    loadSkyboxResource(rm);
-    loadTreeResource(rm);
+    ground.addComponent<Model>(modelArg2);
+    */
 
-    loadSkyBox(sm.getCurrentScene()->getWorld(), rm);
-    loadTree(sm.getCurrentScene()->getWorld(), rm, 1000);
+    // =========== Timer ===========
+    Log& logger = *Log::getInstance();
+    const std::function<void()> timer = [&]()
+    {
+        logger.log(stringFormat("FPS (fixedUpdate): %f\n", fixedUpdateFrameCount / FPLogDelay));
+        logger.log(stringFormat("FPS (unFixedUpdate): %f\n\n", unFixedUpdateFrameCount / FPLogDelay));
+        fixedUpdateFrameCount   = .0;
+        unFixedUpdateFrameCount = .0;
+    };
 
-    ts.addScaledTimer(
-        FPLogDelay,
-        [&]() {
-            std::cout << "FPS (fixedUpdate): " << fixedUpdateFrameCount / FPLogDelay << std::endl;
-            std::cout << "FPS (unFixedUpdate): " << unFixedUpdateFrameCount / FPLogDelay << std::endl << std::endl;
-            fixedUpdateFrameCount   = 0;
-            unFixedUpdateFrameCount = 0;
-        },
-        true);
+    Engine::getInstance()->timeSystem.addScaledTimer(FPLogDelay, timer, true);
 
-    Log::getInstance()->logInitializationEnd("Game");
+    logger.logInitializationEnd("Game");
 }

--- a/projects/GPGame/src/myFpsScript.cpp
+++ b/projects/GPGame/src/myFpsScript.cpp
@@ -27,18 +27,16 @@ MyFpsScript::MyFpsScript(GPE::GameObject& owner) noexcept
     enableUpdate(true);
     enableOnGUI(true);
 
-    input->bindAction("jump",                  EKeyMode::KEY_DOWN,     "game01", this, "jump");
-    input->bindAction("right",                 EKeyMode::KEY_DOWN,     "game01", this, "right");
-    input->bindAction("left",                  EKeyMode::KEY_DOWN,     "game01", this, "left");
-    input->bindAction("forward",               EKeyMode::KEY_DOWN,     "game01", this, "forward");
-    input->bindAction("backward",              EKeyMode::KEY_DOWN,     "game01", this, "backward");
-    input->bindAction("exitGame01",            EKeyMode::KEY_PRESSED,  "game01", this, "leave");
-    input->bindAction("sprint",                EKeyMode::KEY_PRESSED,  "game01", this, "sprintStart");
-    input->bindAction("sprint",                EKeyMode::KEY_RELEASED, "game01", this, "sprintEnd");
-    // input->bindAction("growUpCollider",        EKeyMode::KEY_DOWN,     "game01", this, "growUpSphereCollider");
-    // input->bindAction("growDownCollider",      EKeyMode::KEY_DOWN,     "game01", this, "growDownSphereCollider");
-    input->bindAction("swapInputModeToGame01", EKeyMode::KEY_PRESSED,  "game02", this, "swapInputModeToGame01");
-    input->bindAction("swapInputModeToGame02", EKeyMode::KEY_PRESSED,  "game01", this, "swapInputModeToGame02");
+    input->bindAction("forward",     EKeyMode::KEY_DOWN,     "Game", this, "forward");
+    input->bindAction("backward",    EKeyMode::KEY_DOWN,     "Game", this, "backward");
+    input->bindAction("left",        EKeyMode::KEY_DOWN,     "Game", this, "left");
+    input->bindAction("right",       EKeyMode::KEY_DOWN,     "Game", this, "right");
+    input->bindAction("jump",        EKeyMode::KEY_DOWN,     "Game", this, "jump");
+    input->bindAction("exit",        EKeyMode::KEY_PRESSED,  "Game", this, "leave");
+    input->bindAction("sprintStart", EKeyMode::KEY_PRESSED,  "Game", this, "sprintStart");
+    input->bindAction("sprintEnd",   EKeyMode::KEY_RELEASED, "Game", this, "sprintEnd");
+    // input->bindAction("growUpCollider",        EKeyMode::KEY_DOWN,     "Game", this, "growUpSphereCollider");
+    // input->bindAction("growDownCollider",      EKeyMode::KEY_DOWN,     "Game", this, "growDownSphereCollider");
 
     GPE::Wave testSound3("./resources/sounds/E_Western.wav", "Western");
 
@@ -51,8 +49,8 @@ MyFpsScript::MyFpsScript(GPE::GameObject& owner) noexcept
 
     controller->setHasGravity(true);
     controller->setSpeed(1.f);
-    controller->setMouseSpeed(0.0025f);
-    controller->setGravity(0.1f);
+    controller->setMouseSpeed(.0025f);
+    controller->setGravity(.1f);
 }
 
 
@@ -85,12 +83,10 @@ void MyFpsScript::rotate(const GPM::Vec2& deltaDisplacement)
 {
     using namespace GPM;
 
-    const float speed = controller->getMouseSpeed();
-
     const Quat& orientation{getOwner().getTransform().getSpacialAttribut().rotation};
     const Vec2  axis       {deltaDisplacement.rotated90()};
-    const Quat  rotX       {Quat::angleAxis(axis.x * speed, Vec3::right())};
-    const Quat  rotY       {Quat::angleAxis(axis.y * speed, Vec3::up())};
+    const Quat  rotX       {Quat::angleAxis(axis.x * controller->getMouseSpeed(), Vec3::right())};
+    const Quat  rotY       {Quat::angleAxis(axis.y * controller->getMouseSpeed(), Vec3::up())};
     const Quat  newRot     {rotY * orientation * rotX};
 
     getOwner().getTransform().setRotation(newRot);
@@ -145,7 +141,7 @@ void MyFpsScript::right()
 
 void MyFpsScript::leave()
 {
-    // exit(666);
+    glfwWindowShouldClose(GPE::Engine::getInstance()->window.getGLFWWindow());
 }
 
 
@@ -210,29 +206,10 @@ void MyFpsScript::onGUI()
 }
 
 
-void MyFpsScript::swapInputModeToGame01()
+void MyFpsScript::fixedUpdate(double deltaTime)
 {
-    GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
-
-    iManager.setInputMode("game01");
-    iManager.setCursorTrackingState(true);
-    iManager.setCursorLockState(true);
-}
-
-
-void MyFpsScript::swapInputModeToGame02()
-{
-    GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
-
-    iManager.setInputMode("game02");
-    iManager.setCursorTrackingState(false);
-    iManager.setCursorLockState(false);
-}
-
-
-void MyFpsScript::fixedUpdate(float deltaTime)
-{
-    if (GPE::Engine::getInstance()->inputManager.getInputMode() == "game01")
+    // TODO: find a fix to relieve the user from having to check this, or leave it like that?
+    if (GPE::Engine::getInstance()->inputManager.getInputMode() == "Game")
     {
         const GPM::Vec2 deltaPos = GPE::Engine::getInstance()->inputManager.getCursor().deltaPos;
 

--- a/projects/GPGame/src/myFpsScript.cpp
+++ b/projects/GPGame/src/myFpsScript.cpp
@@ -1,4 +1,245 @@
-#include "myFpsScript.hpp"
+#include <Engine/Core/Tools/ImGuiTools.hpp>
+#include <Engine/Core/Debug/Log.hpp>
+#include <Engine/ECS/Component/BehaviourComponent.hpp>
+#include <Engine/ECS/Component/Physics/CharacterController/CharacterController.hpp>
+#include <Engine/Engine.hpp>
+#include <Engine/Intermediate/GameObject.hpp>
+#include <Engine/Resources/Wave.hpp>
 
-#include "Generated/myFpsScript.rfk.h"
+#include <GLFW/glfw3.h>
+
+#include <imgui.h>
+#include <imgui_internal.h>
+
+#include <MyFpsScript.hpp>
 File_GENERATED
+
+namespace GPG
+{
+
+MyFpsScript::MyFpsScript(GPE::GameObject& owner) noexcept
+    : GPE::BehaviourComponent(owner),
+      input     {&owner.addComponent<GPE::InputComponent>()},
+      source    {&owner.addComponent<GPE::AudioComponent>()},
+      controller{&owner.addComponent<GPE::CharacterController>()}
+{
+    enableFixedUpdate(true);
+    enableUpdate(true);
+    enableOnGUI(true);
+
+    input->bindAction("jump",                  EKeyMode::KEY_DOWN,     "game01", this, "jump");
+    input->bindAction("right",                 EKeyMode::KEY_DOWN,     "game01", this, "right");
+    input->bindAction("left",                  EKeyMode::KEY_DOWN,     "game01", this, "left");
+    input->bindAction("forward",               EKeyMode::KEY_DOWN,     "game01", this, "forward");
+    input->bindAction("backward",              EKeyMode::KEY_DOWN,     "game01", this, "backward");
+    input->bindAction("exitGame01",            EKeyMode::KEY_PRESSED,  "game01", this, "leave");
+    input->bindAction("sprint",                EKeyMode::KEY_PRESSED,  "game01", this, "sprintStart");
+    input->bindAction("sprint",                EKeyMode::KEY_RELEASED, "game01", this, "sprintEnd");
+    // input->bindAction("growUpCollider",        EKeyMode::KEY_DOWN,     "game01", this, "growUpSphereCollider");
+    // input->bindAction("growDownCollider",      EKeyMode::KEY_DOWN,     "game01", this, "growDownSphereCollider");
+    input->bindAction("swapInputModeToGame01", EKeyMode::KEY_PRESSED,  "game02", this, "swapInputModeToGame01");
+    input->bindAction("swapInputModeToGame02", EKeyMode::KEY_PRESSED,  "game01", this, "swapInputModeToGame02");
+
+    GPE::Wave testSound3("./resources/sounds/E_Western.wav", "Western");
+
+    GPE::SourceSettings sourceSettings;
+    sourceSettings.pitch = 1.f;
+    sourceSettings.loop  = AL_TRUE;
+
+    source->setSound("Western", "Western", sourceSettings);
+    source->playSound("Western");
+
+    controller->setHasGravity(true);
+    controller->setSpeed(1.f);
+    controller->setMouseSpeed(0.0025f);
+    controller->setGravity(0.1f);
+}
+
+
+MyFpsScript::~MyFpsScript() noexcept                
+{
+    enableFixedUpdate(false);
+    enableUpdate(false);
+}
+
+/* Variable setter serialization example
+void MyFpsScript::setPrintHello(bool p)
+{
+    if (printHello != p) // Called everytime if no if 
+    {
+        printHello = p;
+
+        if (printHello)
+        {
+            GPE::Log::getInstance()->log("Hello world!");
+        }
+        else
+        {
+            GPE::Log::getInstance()->log("Set me to true!");
+        }
+    }
+}
+*/
+
+void MyFpsScript::rotate(const GPM::Vec2& deltaDisplacement)
+{
+    using namespace GPM;
+
+    const float speed = controller->getMouseSpeed();
+
+    const Quat& orientation{getOwner().getTransform().getSpacialAttribut().rotation};
+    const Vec2  axis       {deltaDisplacement.rotated90()};
+    const Quat  rotX       {Quat::angleAxis(axis.x * speed, Vec3::right())};
+    const Quat  rotY       {Quat::angleAxis(axis.y * speed, Vec3::up())};
+    const Quat  newRot     {rotY * orientation * rotX};
+
+    getOwner().getTransform().setRotation(newRot);
+}
+
+
+void MyFpsScript::jump()
+{
+    if (controller->getJumping() == false)
+    {
+        controller->addForce(GPM::Vec3::up() * 3.f);
+        controller->setJumping(true);
+    }
+}
+
+
+void MyFpsScript::forward()
+{
+    GPM::Vec3 vec = getOwner().getTransform().getVectorForward();
+    vec.y         = 0;
+    controller->move(-vec);
+    // rigidbody.rigidbody->addForce(vec * -speed, physx::PxForceMode::eFORCE);
+}
+
+
+void MyFpsScript::backward()
+{
+    GPM::Vec3 vec = getOwner().getTransform().getVectorForward();
+    vec.y         = 0;
+    controller->move(vec);
+    // rigidbody.rigidbody->addForce(vec * speed, physx::PxForceMode::eFORCE);
+}
+
+
+void MyFpsScript::left()
+{
+    GPM::Vec3 vec = getOwner().getTransform().getVectorRight();
+    vec.y         = 0;
+    controller->move(-vec);
+    // rigidbody.rigidbody->addForce(vec * -speed, physx::PxForceMode::eFORCE);
+}
+
+
+void MyFpsScript::right()
+{
+    GPM::Vec3 vec = getOwner().getTransform().getVectorRight();
+    vec.y         = 0;
+    controller->move(vec);
+    // rigidbody.rigidbody->addForce(vec * speed, physx::PxForceMode::eFORCE);
+}
+
+
+void MyFpsScript::leave()
+{
+    // exit(666);
+}
+
+
+void MyFpsScript::sprintStart()
+{
+    controller->setSpeed(controller->getSpeed() * 2.f);
+}
+
+
+void MyFpsScript::sprintEnd()
+{
+    controller->setSpeed(controller->getSpeed() * .5f);
+}
+
+/*
+void MyFpsScript::growUpSphereCollider()
+{
+    // collider.setRadius(collider.getRadius() + 1);
+}
+
+
+void MyFpsScript::growDownSphereCollider()
+{
+    // collider.setRadius(collider.getRadius() - 1);
+}
+*/
+
+void MyFpsScript::onGUI()
+{
+    static float ratio = 0.08f;
+
+    ImGui::DragFloat("Ratio", &ratio, 0.01f, 0.f, 1.f);
+
+    ImVec2 size = {ImGui::GetWindowSize().x * ratio, ImGui::GetWindowSize().y * ratio};
+
+    ImGui::SetNextElementLayout(0.f, 0.f, size, ImGui::EHAlign::Left, ImGui::EVAlign::Top);
+    ImGui::Button("Top/Left", size);
+
+    ImGui::SetNextElementLayout(0.5, 0.f, size, ImGui::EHAlign::Middle, ImGui::EVAlign::Top);
+    ImGui::Button("Top", size);
+
+    ImGui::SetNextElementLayout(1.f, 0.f, size, ImGui::EHAlign::Right, ImGui::EVAlign::Top);
+    ImGui::Button("Top/Right", size);
+
+    ImGui::SetNextElementLayout(0.f, 0.5f, size, ImGui::EHAlign::Left);
+    ImGui::Button("Mid/Left", size);
+
+    ImGui::SetNextElementLayout(0.5f, 0.5f, size);
+    ImGui::Button("Mid", size);
+
+    ImGui::SetNextElementLayout(1.f, 0.5f, size, ImGui::EHAlign::Right);
+    ImGui::Button("Mid/Right", size);
+
+    ImGui::SetNextElementLayout(0.f, 1.f, size, ImGui::EHAlign::Left, ImGui::EVAlign::Bottom);
+    ImGui::Button("Bot/Left", size);
+
+    ImGui::SetNextElementLayout(0.5f, 1.f, size, ImGui::EHAlign::Middle, ImGui::EVAlign::Bottom);
+    ImGui::Button("Bot", size);
+
+    ImGui::SetNextElementLayout(1.f, 1.f, size, ImGui::EHAlign::Right, ImGui::EVAlign::Bottom);
+    ImGui::Button("Bot/Right", size);
+}
+
+
+void MyFpsScript::swapInputModeToGame01()
+{
+    GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
+
+    iManager.setInputMode("game01");
+    iManager.setCursorTrackingState(true);
+    iManager.setCursorLockState(true);
+}
+
+
+void MyFpsScript::swapInputModeToGame02()
+{
+    GPE::InputManager& iManager = GPE::Engine::getInstance()->inputManager;
+
+    iManager.setInputMode("game02");
+    iManager.setCursorTrackingState(false);
+    iManager.setCursorLockState(false);
+}
+
+
+void MyFpsScript::fixedUpdate(float deltaTime)
+{
+    if (GPE::Engine::getInstance()->inputManager.getInputMode() == "game01")
+    {
+        const GPM::Vec2 deltaPos = GPE::Engine::getInstance()->inputManager.getCursor().deltaPos;
+
+        if (deltaPos.x || deltaPos.y)
+            rotate(deltaPos);
+    }
+    controller->update(deltaTime);
+}
+
+} // End of namespace GPG


### PR DESCRIPTION
## Description
Here is what changed in the branch:
- Added a game view window
- Added control of the game simulation from the game bar:
    \- "Play" launches the simulation
    \- "Pause" freeze the simulation
    \- "Stop" currently as the same effect as "Pause" (scene reloading will soon be included)
- Fixed level editor view being rendered on top of the game view and vice-versa
- Fixed some caveats in `InputManager` and `InputComponent`, and added a few methods
- Fixed picking shader not returning the object under the cursor
- Cleaned `Game` and `MyFpsScript` class implementation
- The level editor and game view are now clearly separated, 2 independant cameras are used
- The controls are now as follow:
    \- Keep right-click in the level editor to move the camera around (Z, Q, S, D + mouse)
    \- Left-click once in the level editor to select an object
    \- Left-click once in the game view while "Play" is toggled to capture the mouse and switch to game's input
    \- Press escape to get back the mouse's cursor and disable game's inputs
- Turned many `#include "..."` into `#include <...>` where appropriate, removed some of them
- Fixed/simplified syntax here and there in the code

What is to come:
- Scene reloading
- gpm submodule update
- Various small fixes (see [Trello "Bug" column](https://trello.com/b/Hbu22QJx/gp-engine))

## How to test
1. Checkout this branch
2. Play around with the simulation, the window, and try to make it crash!

**I will take care of the merge with develop and merge conflicts**