### PR TITLE
Quick fix for a crash related to scene loading

### DIFF
--- a/editor/src/GameViewer.cpp
+++ b/editor/src/GameViewer.cpp
@@ -70,10 +70,11 @@ void GameViewer::render(EditorStartup& startup)
             Camera* mainCam             = sceneRenderer.getMainCamera();
 
             sceneRenderer.setActiveCamera(mainCam);
+            mainCam = sceneRenderer.getMainCamera();
             mainCam->setAspect(size.x / size.y);
-        }
+        
 
-        { // Update game viewport
+         // Update game viewport
             const ImVec2       winPos{ImGui::GetWindowPos()};
             const ImGuiWindow* win   {ImGui::GetCurrentWindow()};
             startup.game().setViewport(winPos.x + win->Viewport->CurrWorkOffsetMin.x,

--- a/engine/src/RenderSystem.cpp
+++ b/engine/src/RenderSystem.cpp
@@ -293,8 +293,8 @@ void RenderSystem::setMainCamera(Camera* newMainCamera) noexcept
 {
     m_mainCamera = newMainCamera;
 
-    if (!m_activeCamera)
-        m_activeCamera = newMainCamera;
+    if (!m_mainCamera && m_activeCamera)
+        m_mainCamera = m_activeCamera;
 }
 
 Camera* RenderSystem::getMainCamera() noexcept
@@ -305,7 +305,13 @@ Camera* RenderSystem::getMainCamera() noexcept
 
 void RenderSystem::setActiveCamera(Camera* newActiveCamera) noexcept
 {
-    m_activeCamera = newActiveCamera;
+    if (!m_activeCamera || newActiveCamera)
+    {
+        m_activeCamera = newActiveCamera;
+
+        if (!m_mainCamera)
+            m_mainCamera = m_activeCamera;
+    }
 }
 
 Camera* RenderSystem::getActiveCamera() noexcept


### PR DESCRIPTION
## Description

The main and active camera were not appropriately changed/set.
This brings a fix which should prevent a crash when loading a new scene