### PR TITLE
Fixed inspected target object invalidation crash

### DIFF
--- a/editor/include/Editor/Editor.hpp
+++ b/editor/include/Editor/Editor.hpp
@@ -86,6 +86,8 @@ public:
     void saveCurrentScene();
     void reloadCurrentScene();
     void unbindCurrentScene();
+
+    void checkInspectedObject();
 };
 
 } // End of namespace Editor

--- a/editor/src/Editor.cpp
+++ b/editor/src/Editor.cpp
@@ -537,4 +537,17 @@ bool Editor::isRunning()
     return !glfwWindowShouldClose(m_window);
 }
 
+void Editor::checkInspectedObject()
+{
+    if (inspectedObject)
+    {
+        const GameObject* const asGameObject = dynamic_cast<GameObject*>(inspectedObject);
+
+        if (asGameObject && asGameObject->isDead())
+        {
+            inspectedObject = nullptr;
+        }
+    }
+}
+
 } // End of namespace Editor

--- a/editor/src/EditorStartup.cpp
+++ b/editor/src/EditorStartup.cpp
@@ -219,6 +219,8 @@ void EditorStartup::playGame()
             m_engine->sceneManager.getCurrentScene()->sceneRenderer.updateDebug(deltaTime);
             m_engine->sceneManager.getCurrentScene()->behaviourSystem.updateEditor(deltaTime);
             m_engine->sceneManager.getCurrentScene()->sceneRenderer.update(deltaTime);
+
+            m_editor.checkInspectedObject();
             m_engine->sceneManager.getCurrentScene()->getWorld().updateSelfAndChildren();
 
             m_game->update(unscaledDeltaTime, deltaTime);

--- a/engine/include/Engine/Intermediate/GameObject.hpp
+++ b/engine/include/Engine/Intermediate/GameObject.hpp
@@ -120,7 +120,7 @@ namespace GPE RFKNamespace()
          */
         inline void setName(const char* newName) noexcept;
 
-        inline bool isDead();
+        inline bool isDead() const;
 
         /**
          * @brief Get the Transform object

--- a/engine/include/Engine/Intermediate/GameObject.inl
+++ b/engine/include/Engine/Intermediate/GameObject.inl
@@ -53,7 +53,7 @@ inline GameObject* GameObject::getParent() noexcept
     return m_parent;
 }
 
-inline bool GameObject::isDead()
+inline bool GameObject::isDead() const
 {
     return m_isDead;
 }

--- a/engine/src/GameObject.cpp
+++ b/engine/src/GameObject.cpp
@@ -12,7 +12,7 @@
 #include <Generated/GameObject.rfk.h>
 File_GENERATED
 
-    using namespace GPE;
+using namespace GPE;
 using namespace GPM;
 
 unsigned int GameObject::m_currentID = 0;


### PR DESCRIPTION
## Description
This fixes the crash which was occuring when the inspected `GameObject` in the editor turned dead, and was subsequently deleted.

## How to test
1. Select a zombie in the scene
2. Set its current and max health to `0`
3. Keep the zombie selected, and launch the simulation
4. Wait and see if the zombie gets unselected in the inspector