### PR TITLE
Quick fix for zombie animation

### DIFF
--- a/projects/GPGame/src/BaseEnemy.cpp
+++ b/projects/GPGame/src/BaseEnemy.cpp
@@ -75,7 +75,7 @@ void BaseEnemy::update(double deltaTime)
             GPE::Animation* anim = GPE::Engine::getInstance()->animResourcesManager.get<GPE::Animation>(src);
             if (anim == nullptr)
             {
-                Engine::getInstance()->animResourcesManager.add<Animation>(src, readAnimationFile(src));
+                anim = &Engine::getInstance()->animResourcesManager.add<Animation>(src, readAnimationFile(src));
             }
 
             m_animComp->playAnimation(anim);


### PR DESCRIPTION
## Description
This is a quick fix for a missing variable assignation in `BaseEnemy`, which sometimes causes a crash.

## How to test
Move a zombie already in the scene somewhere he won't move, and see if it plays its animation correctly