### PR TITLE
Windowed mode, some opti and fixes

### DIFF
--- a/engine/include/Engine/Core/Rendering/Window/WindowGLFW.hpp
+++ b/engine/include/Engine/Core/Rendering/Window/WindowGLFW.hpp
@@ -23,7 +23,8 @@ public:
     };
 
 protected:
-    GLFWwindow* m_window = nullptr;
+    GLFWwindow* m_window     = nullptr;
+    bool        isFullscreen = true;
 
 public:
     Window(const CreateArg& arg) noexcept;
@@ -46,7 +47,7 @@ public:
      */
     [[nodiscard]] constexpr inline const GLFWwindow* getGLFWWindow() const noexcept;
     [[nodiscard]] constexpr inline GLFWwindow*       getGLFWWindow() noexcept;
-    
+
     void close();
 
     /**
@@ -60,8 +61,10 @@ public:
     void maximize();
     void minimize();
     void setFullscreen();
+    void setWindowed();
     void show();
     void hide();
+    void switchFullscreenOrWindowed();
 };
 
 #include "WindowGLFW.inl"

--- a/engine/include/Engine/ECS/Component/Model.hpp
+++ b/engine/include/Engine/ECS/Component/Model.hpp
@@ -117,6 +117,8 @@ namespace GPE RFKNamespace()
 
         bool hasAnimationsLinked() const;
 
+        const SubModel& getSubModel(size_t index) const;
+
         /**
          * @brief Function to return the local AABB (do not considere the position, scale and rotation of transform)
          * @return

--- a/engine/include/Engine/ECS/System/RenderSystem.hpp
+++ b/engine/include/Engine/ECS/System/RenderSystem.hpp
@@ -140,7 +140,7 @@ public:
     void resetCurrentRenderPassKey();
 
     void renderFurstum(const Frustum& frustum, float size);
-    bool isOnFrustum(const Frustum& camFrustum, const SubModel* pSubModel) const noexcept;
+    static bool isOnFrustum(const Frustum& camFrustum, const SubModel* pSubModel) noexcept;
     void drawModelPart(const SubModel& subModel);
     void sendModelDataToShader(Camera& camToUse, Shader& shader, const GPM::Mat4& modelMatrix);
     void sendDataToInitShader(Camera& camToUse, Shader& shader);

--- a/engine/src/AnimationComponent.cpp
+++ b/engine/src/AnimationComponent.cpp
@@ -10,6 +10,7 @@
 #include <Engine/Resources/Animation/Animation.hpp>
 #include <Engine/Resources/Animation/Skeleton.hpp>
 #include <Engine/Resources/Animation/Skin.hpp>
+#include <Engine/ECS/Component/Camera.hpp>
 #include <assimp/Importer.hpp>  // C++ importer interface
 #include <assimp/postprocess.h> // Post processing flags
 #include <assimp/scene.h>       // Output data structure
@@ -128,7 +129,17 @@ void AnimationComponent::update(float deltaTime)
         }
 
         m_currentTime = fmod(m_currentTime, m_currentAnimation->getDuration());
-        calculateBoneTransform(m_skeleton->getRoot(), GPM::Mat4::identity());
+
+        if (RenderSystem::isOnFrustum(GPE::Engine::getInstance()->sceneManager.getCurrentScene()->sceneRenderer.getMainCamera()->getFrustum(), &m_model->getSubModel(m_subModelIndex)))
+        {
+
+            calculateBoneTransform(m_skeleton->getRoot(), GPM::Mat4::identity());
+        }
+        else
+        {
+            int i = 0;
+            i += 1;
+        }
     }
 }
 

--- a/engine/src/AnimationComponent.cpp
+++ b/engine/src/AnimationComponent.cpp
@@ -135,11 +135,6 @@ void AnimationComponent::update(float deltaTime)
 
             calculateBoneTransform(m_skeleton->getRoot(), GPM::Mat4::identity());
         }
-        else
-        {
-            int i = 0;
-            i += 1;
-        }
     }
 }
 

--- a/engine/src/Model.cpp
+++ b/engine/src/Model.cpp
@@ -298,6 +298,16 @@ bool Model::hasAnimationsLinked() const
     return false;
 }
 
+const SubModel& Model::getSubModel(size_t index) const
+{
+    if (index < m_subModels.size())
+    {
+        auto it = m_subModels.begin();
+        std::advance(it, index);
+        return *it;
+    }
+}
+
 GPM::AABB Model::getLocalAABB()
 {
     return AABB{getLocalAABBMin(), getLocalAABBMAx()};

--- a/engine/src/RenderSystem.cpp
+++ b/engine/src/RenderSystem.cpp
@@ -161,7 +161,7 @@ void RenderSystem::renderFurstum(const Frustum& frustum, float size)
     drawDebugQuad(pos, frustum.bottomFace.getNormal(), Vec3::one() * size, ColorRGBA{0.5f, 1.0f, 0.5f, 0.8f});
 }
 
-bool RenderSystem::isOnFrustum(const Frustum& camFrustum, const SubModel* pSubModel) const noexcept
+bool RenderSystem::isOnFrustum(const Frustum& camFrustum, const SubModel* pSubModel) noexcept
 {
     switch (pSubModel->pMesh->getBoundingVolumeType())
     {

--- a/engine/src/WindowGLFW.cpp
+++ b/engine/src/WindowGLFW.cpp
@@ -72,6 +72,20 @@ void Window::setFullscreen()
 
     // switch to full screen
     glfwSetWindowMonitor(m_window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+
+    isFullscreen = true;
+}
+
+void Window::setWindowed()
+{
+    GLFWmonitor*       monitor = glfwGetPrimaryMonitor();
+    const GLFWvidmode* mode    = glfwGetVideoMode(glfwGetPrimaryMonitor());
+
+    // switch to full screen
+    glfwSetWindowMonitor(m_window, NULL, 0, 0, mode->width, mode->height, mode->refreshRate);
+
+    glfwShowWindow(m_window);
+    isFullscreen = false;
 }
 
 void Window::maximize()
@@ -93,4 +107,16 @@ void Window::show()
 void Window::hide()
 {
     glfwHideWindow(m_window);
+}
+
+void Window::switchFullscreenOrWindowed()
+{
+    if (isFullscreen)
+    {
+        setWindowed();
+    }
+    else
+    {
+        setFullscreen();
+    }
 }

--- a/launcher/gameStartup.cpp
+++ b/launcher/gameStartup.cpp
@@ -97,6 +97,20 @@ void GameStartup::update()
 {
     m_engine->timeSystem.update(m_fixedUpdate, m_update, m_render);
 
+    static bool wasKeyPRessed = false;
+    if (glfwGetKey(m_engine->window.getGLFWWindow(), GLFW_KEY_F11) == GLFW_PRESS)
+    {
+        if (!wasKeyPRessed)
+        {
+            m_engine->window.switchFullscreenOrWindowed();
+            wasKeyPRessed = true;
+        }
+    }
+    else
+    {
+        wasKeyPRessed = false;
+    }
+
     Engine::getInstance()->isRunning = !glfwWindowShouldClose(m_engine->window.getGLFWWindow());
 }
 

--- a/projects/GPGame/src/BaseEnemy.cpp
+++ b/projects/GPGame/src/BaseEnemy.cpp
@@ -65,19 +65,6 @@ void BaseEnemy::update(double deltaTime)
 {
     if (isDead())
     {
-        // if (m_deathAnimation != nullptr)
-        //{
-        //    for (GPE::AnimationComponent* animComp : m_animComps)
-        //    {
-        //        if (animComp != nullptr)
-        //        {
-        //            animComp->setNextAnim(m_deathAnimation, m_animTransitionTime);
-        //            animComp->shouldLoop     = false;
-        //            animComp->shouldNextLoop = false;
-        //        }
-        //    }
-        //}
-
         m_animDeathCounter += float(deltaTime);
 
         if (m_animDeathCounter >= m_animDeathCounterMax)

--- a/projects/GPGame/src/BaseEnemy.cpp
+++ b/projects/GPGame/src/BaseEnemy.cpp
@@ -39,6 +39,19 @@ void BaseEnemy::start()
     GAME_ASSERT(m_controller, "Null");
 
     m_source->playSound("Zombie", true, false);
+
+    m_currentState = EState::RUNNING;
+    if (m_walkAnimation != nullptr)
+    {
+        for (GPE::AnimationComponent* animComp : m_animComps)
+        {
+            if (animComp != nullptr)
+            {
+                animComp->playAnimation(nullptr);
+                animComp->playAnimation(m_walkAnimation, m_animTransitionTime, m_walkScale);
+            }
+        }
+    }
 }
 
 void BaseEnemy::onPostLoad()

--- a/projects/GPGame/src/MainMenu.cpp
+++ b/projects/GPGame/src/MainMenu.cpp
@@ -72,6 +72,12 @@ void MainMenu::onGUI()
     }
     PopFont();
     ImGui::SetWindowFontScale(previousFontScale);
+
+    std::string creditsText     = "Credits : \n - Jonathan Six \n - Sami Amara \n - Thomas Dallard \n - William Nardone"; 
+    ImVec2      creditsTextSize = ImGui::CalcTextSize(creditsText.c_str());
+    SetCursorPosX(GetWindowSize().x - creditsTextSize.x - 30);
+    SetCursorPosY(GetWindowSize().y - creditsTextSize.y - 20);
+    ImGui::Text(creditsText.c_str(), creditsTextSize);
 }
 
 MainMenu::~MainMenu() noexcept


### PR DESCRIPTION
- In GPLauncher mode, you can now press F11 to switch between fullscreen and windowed mode.
- Frustum Culling is now used to prevent AnimationComponents from computing unused data.
- Men and women zombies now have the correct animation speed at the start. 
- Credits added !